### PR TITLE
Add IWallet implementation for BWS (via proxy)

### DIFF
--- a/server_extensions_extra/res/batm-extensions.xml
+++ b/server_extensions_extra/res/batm-extensions.xml
@@ -17,6 +17,11 @@
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>
             </wallet>
+            <wallet prefix="bitcore" name="BitCore Wallet">
+                <param name="apiKey" />
+                <param name="proxyUrl" />
+                <cryptocurrency>BTC</cryptocurrency>
+            </wallet>
             <ratesource prefix="bitcoinaverage" name ="BitcoinAverage.com" >
                 <cryptocurrency>BTC</cryptocurrency>
             </ratesource>

--- a/server_extensions_extra/src/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -25,6 +25,7 @@ import com.generalbytes.batm.server.extensions.extra.bitcoin.paymentprocessors.c
 import com.generalbytes.batm.server.extensions.extra.bitcoin.sources.BitcoinAverageRateSource;
 import com.generalbytes.batm.server.extensions.extra.bitcoin.sources.FixPriceRateSource;
 import com.generalbytes.batm.server.extensions.extra.bitcoin.wallets.bitcoind.BATMBitcoindRPCWallet;
+import com.generalbytes.batm.server.extensions.extra.bitcoin.wallets.bitcore.BitcoreWallet;
 import com.generalbytes.batm.server.extensions.extra.bitcoin.wallets.coinkite.CoinkiteWallet;
 
 import java.math.BigDecimal;
@@ -113,6 +114,12 @@ public class BitcoinExtension implements IExtension{
                     accountNumber = st.nextToken();
                 }
                 return new CoinkiteWallet(apikey,apiSecret,accountNumber);
+            }else if ("bitcore".equalsIgnoreCase(walletType)) { //bitcore:apiKey:proxyUrl
+                String apiKey = st.nextToken();
+                // the next token is a URL, so we can't use : as a delimiter
+                // instead use \n and then remove the leading :
+                String proxyUrl = st.nextToken("\n").replaceFirst(":", "");
+                return new BitcoreWallet(apiKey, proxyUrl);
             }
         }
         return null;

--- a/server_extensions_extra/src/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitcore/BitcoreWallet.java
+++ b/server_extensions_extra/src/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitcore/BitcoreWallet.java
@@ -1,0 +1,100 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2016 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.bitcoin.wallets.bitcore;
+
+import com.generalbytes.batm.server.extensions.ICurrencies;
+import com.generalbytes.batm.server.extensions.IWallet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import si.mazi.rescu.ClientConfig;
+import si.mazi.rescu.HttpStatusIOException;
+import si.mazi.rescu.RestProxyFactory;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BitcoreWallet implements IWallet {
+    private static final Logger log = LoggerFactory.getLogger(BitcoreWallet.class);
+    private static final BigDecimal coin = BigDecimal.valueOf(Math.pow(10, 8));
+
+    private final String apiKey;
+    private final IBitcoreProxyAPI api;
+
+    private BigDecimal fromSatoshis(long amount) {
+        return BigDecimal.valueOf(amount).divide(coin);
+    }
+
+    private long toSatoshis(BigDecimal amount) {
+        return amount.multiply(coin).longValue();
+    }
+
+    public BitcoreWallet(String apiKey, String proxyUrl) {
+        this.apiKey = apiKey;
+        api = RestProxyFactory.createProxy(IBitcoreProxyAPI.class, proxyUrl);
+    }
+
+    @Override
+    public String getCryptoAddress(String cryptoCurrency) {
+        try {
+            return api.getAddress(cryptoCurrency);
+        } catch (HttpStatusIOException e) {
+            log.error(e.getHttpBody());
+        } catch (IOException e) {
+            log.error("", e);
+        }
+        return null;
+    }
+
+    @Override
+    public BigDecimal getCryptoBalance(String cryptoCurrency) {
+        try {
+            return fromSatoshis(api.getCryptoBalance(cryptoCurrency));
+        } catch (HttpStatusIOException e) {
+            log.error(e.getHttpBody());
+        } catch (IOException e) {
+            log.error("", e);
+        }
+        return null;
+    }
+
+    @Override
+    public String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
+        try {
+            return api.sendCoins(this.apiKey, destinationAddress, toSatoshis(amount), cryptoCurrency, description);
+        } catch (HttpStatusIOException e) {
+            log.error(e.getHttpBody());
+        } catch (IOException e) {
+            log.error("", e);
+        }
+        return null;
+    }
+
+    @Override
+    public Set<String> getCryptoCurrencies() {
+        HashSet<String> s = new HashSet<String>();
+        s.add(ICurrencies.BTC);
+        return s;
+    }
+
+    @Override
+    public String getPreferredCryptoCurrency() {
+        return ICurrencies.BTC;
+    }
+}

--- a/server_extensions_extra/src/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitcore/IBitcoreProxyAPI.java
+++ b/server_extensions_extra/src/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitcore/IBitcoreProxyAPI.java
@@ -1,0 +1,39 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2016 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.bitcoin.wallets.bitcore;
+
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+public interface IBitcoreProxyAPI {
+    @GET
+    @Path("address")
+    String getAddress(@QueryParam("crypto") String cryptoCurrency) throws IOException;
+
+    @GET
+    @Path("balance")
+    long getCryptoBalance(@QueryParam("crypto") String cryptoCurrency) throws IOException;
+
+    @POST
+    @Path("send/{address}")
+    String sendCoins(@HeaderParam("x-api-key") String apiKey, @PathParam("address") String destinationAddress, @QueryParam("amount") long amount, @QueryParam("crypto") String cryptoCurrency, @QueryParam("description") String description) throws IOException;
+}


### PR DESCRIPTION
Here's the IWallet implementation I was working on.

It communicates with an instance of BitCore wallet service, but since there is no Java client for it (and it's fairly complicated), I use a Node.js proxy. That project is here: https://github.com/chrisrico/babywasp

Anybody can install this Node program on a server and use it to generate a wallet (1-of-1 up to 4-of-6 multisig). The wallet file is then encrypted with a randomly generated private key, which is used as an API key by the BATM server. The nice thing about this is that the proxy can be pointed at any wallet service, even Bitpay's (in fact it defaults to theirs). When the wallet is created, it also displays the key converted to a 12 word mnemonic. Using this mnemonic, the encryption key on the wallet can be changed, in effect revoking the old API key.
