### PR TITLE
fixed typo in batm-extensions.xml, ntxfix->nxtfix...

### DIFF
--- a/server_extensions_extra/res/batm-extensions.xml
+++ b/server_extensions_extra/res/batm-extensions.xml
@@ -239,7 +239,7 @@
             <param name="accountRS" />
             <cryptocurrency>NXT</cryptocurrency>
         </wallet>
-        <ratesource prefix="ntxfix" name ="Fix Price" >
+        <ratesource prefix="nxtfix" name ="Fix Price" >
             <param name="price" />
             <cryptocurrency>NXT</cryptocurrency>
         </ratesource>


### PR DESCRIPTION
... , which most likely causes NXT fixed price ratesource not getting created when needed.