### PR TITLE
BATM-780 migrate to the new coinmarket pro-api

### DIFF
--- a/server_extensions_extra/build.gradle
+++ b/server_extensions_extra/build.gradle
@@ -60,8 +60,12 @@ dependencies {
     runtime(group: 'com.madgag.spongycastle', name: 'core', version: '1.51.0.0')
     runtime(group: 'com.google.protobuf',  name: 'protobuf-java', version: '2.6.1')
 
-    generalBytesCompile(group: 'com.generalbytes.bitrafael.public', name: 'bitrafael-client', version: bitrafaelVersion)
-    githubCompile(group: 'com.github.GENERALBYTESCOM.bitrafael_public', name: 'bitrafael-client', version: bitrafaelVersion)
+    generalBytesCompile(group: 'com.generalbytes.bitrafael.public', name: 'bitrafael-client', version: bitrafaelVersion) {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
+    }
+    githubCompile(group: 'com.github.GENERALBYTESCOM.bitrafael_public', name: 'bitrafael-client', version: bitrafaelVersion) {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
+    }
 
     testCompile (group: 'junit', name: 'junit', version: '4.10')
     testCompile(group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3')

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/anon/ANONExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/anon/ANONExtension.java
@@ -79,11 +79,15 @@ public class ANONExtension extends AbstractExtension {
             StringTokenizer st = new StringTokenizer(sourceLogin, ":");
             String exchangeType = st.nextToken();
             if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             } else if ("anonfix".equalsIgnoreCase(exchangeType)) {
                 BigDecimal rate = BigDecimal.ZERO;
                 if (st.hasMoreTokens()) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoinprivate/BitcoinPrivateExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoinprivate/BitcoinPrivateExtension.java
@@ -62,11 +62,15 @@ public class BitcoinPrivateExtension extends AbstractExtension {
             StringTokenizer st = new StringTokenizer(sourceLogin, ":");
             String exchangeType = st.nextToken();
             if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             } else if ("btcpfix".equalsIgnoreCase(exchangeType)) {
                 BigDecimal rate = BigDecimal.ZERO;
                 if (st.hasMoreTokens()) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/cloakcoin/CloakcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/cloakcoin/CloakcoinExtension.java
@@ -59,10 +59,14 @@ public class CloakcoinExtension extends AbstractExtension {
             String exchangeType = st.nextToken();
             if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
                 String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
                     preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferredFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }else if ("cloakcoinfix".equalsIgnoreCase(exchangeType)) {
                 BigDecimal rate = BigDecimal.ZERO;
                 if (st.hasMoreTokens()) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashExtension.java
@@ -94,11 +94,15 @@ public class DashExtension extends AbstractExtension{
                 }
                 return new FixPriceRateSource(rate, preferedFiatCurrency);
             } else if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CmcTickerData.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CmcTickerData.java
@@ -20,20 +20,20 @@ package com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap
 import java.util.Map;
 
 public class CmcTickerData {
-    private Map<String, CmcTickerQuote> quotes;
+    private Map<String, CmcTickerQuote> quote;
 
-    public Map<String, CmcTickerQuote> getQuotes() {
-        return quotes;
+    public Map<String, CmcTickerQuote> getQuote() {
+        return quote;
     }
 
-    public void setQuotes(Map<String, CmcTickerQuote> quotes) {
-        this.quotes = quotes;
+    public void setQuote(Map<String, CmcTickerQuote> quote) {
+        this.quote = quote;
     }
 
     @Override
     public String toString() {
         return "CmcTickerData{" +
-            "quotes=" + quotes +
+            "quote=" + quote +
             '}';
     }
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CmcTickerResponse.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CmcTickerResponse.java
@@ -17,14 +17,16 @@
  ************************************************************************************/
 package com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap;
 
-public class CmcTickerResponse {
-    private CmcTickerData data;
+import java.util.Map;
 
-    public CmcTickerData getData() {
+public class CmcTickerResponse {
+    private Map<String, CmcTickerData> data;
+
+    public Map<String, CmcTickerData> getData() {
         return data;
     }
 
-    public void setData(CmcTickerData data) {
+    public void setData(Map<String, CmcTickerData> data) {
         this.data = data;
     }
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/ICoinmarketcapAPI.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/ICoinmarketcapAPI.java
@@ -19,6 +19,7 @@ package com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 // https://pro-api.coinmarketcap.com/v1/
 // https://coinmarketcap.com/api/documentation/v1
@@ -28,5 +29,5 @@ import javax.ws.rs.core.MediaType;
 public interface ICoinmarketcapAPI {
     @GET
     @Path("/cryptocurrency/quotes/latest")
-    CmcTickerResponse getTicker(@HeaderParam("X-CMC_PRO_API_KEY") String apikey, @QueryParam("symbol") String symbol, @QueryParam("convert") String fiatCurrency);
+    CmcTickerResponse getTicker(@HeaderParam("X-CMC_PRO_API_KEY") String apikey, @QueryParam("symbol") String symbol, @QueryParam("convert") String fiatCurrency) throws IOException;
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/ICoinmarketcapAPI.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/ICoinmarketcapAPI.java
@@ -19,21 +19,14 @@ package com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
-import java.util.Map;
-@Path("/v2")
+
+// https://pro-api.coinmarketcap.com/v1/
+// https://coinmarketcap.com/api/documentation/v1
+// replaces legacy "v2" API
+@Path("/v1")
 @Produces(MediaType.APPLICATION_JSON)
 public interface ICoinmarketcapAPI {
     @GET
-    @Path("/ticker/{id}/")
-    CmcTickerResponse  getTicker(@PathParam("id") Integer id, @QueryParam("convert") String fiatCurrency);
-
-    /**
-     * Method getListings() returns map which contain all suported crypto currencies.
-     * For all cryptocurrencies there is associated id.
-     *
-     * @return Map of cryptocurrencies
-     */
-    @GET
-    @Path("/listings")
-    Map<String, Object> getListings();
+    @Path("/cryptocurrency/quotes/latest")
+    CmcTickerResponse getTicker(@HeaderParam("X-CMC_PRO_API_KEY") String apikey, @QueryParam("symbol") String symbol, @QueryParam("convert") String fiatCurrency);
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/electra/ElectraExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/electra/ElectraExtension.java
@@ -90,11 +90,15 @@ public class ElectraExtension extends AbstractExtension{
                 return new FixPriceRateSource(rate, preferedFiatCurrency);
             }
             else if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/linda/LindaExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/linda/LindaExtension.java
@@ -89,11 +89,15 @@ public class LindaExtension extends AbstractExtension{
                 }
                 return new FixPriceRateSource(rate, preferedFiatCurrency);
             } else if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lisk/LiskExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lisk/LiskExtension.java
@@ -81,10 +81,14 @@ public class LiskExtension extends AbstractExtension{
             }
             else if ("binanceRateSource".equalsIgnoreCase(exchangeType)) {
                 String preferedFiatCurrency = Currencies.USD;
+                String coinmarketcapApiKey = null;
                 if (st.hasMoreTokens()) {
                     preferedFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new BinanceRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    coinmarketcapApiKey = st.nextToken();
+                }
+                return new BinanceRateSource(preferedFiatCurrency, coinmarketcapApiKey);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lisk/sources/binance/BinanceRateSource.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lisk/sources/binance/BinanceRateSource.java
@@ -29,9 +29,11 @@ import java.util.*;
 public class BinanceRateSource implements IRateSource {
 
     private BinanceAPI api;
+    private final String coinmarketcapApiKey;
     private String preferredFiatCurrency = Currencies.USD;
 
-    public BinanceRateSource(String preferedFiatCurrency) {
+    public BinanceRateSource(String preferedFiatCurrency, String coinmarketcapApiKey) {
+        this.coinmarketcapApiKey = coinmarketcapApiKey;
         api = RestProxyFactory.createProxy(BinanceAPI.class, "https://api.binance.com");
         
         if (Currencies.USD.equalsIgnoreCase(preferedFiatCurrency)) {
@@ -74,7 +76,7 @@ public class BinanceRateSource implements IRateSource {
         }
         final BinanceTickerData btcUsdt = api.getTicker("BTCUSDT");
         final BinanceTickerData lskBtc = api.getTicker(cryptoCurrency + "BTC");
-        CoinmarketcapRateSource coinMarketCapSource = new CoinmarketcapRateSource(fiatCurrency);
+        CoinmarketcapRateSource coinMarketCapSource = new CoinmarketcapRateSource(coinmarketcapApiKey, fiatCurrency);
         BigDecimal lastUsdtFiat = coinMarketCapSource.getExchangeRateLast("USDT", fiatCurrency);
         if (lastUsdtFiat != null && btcUsdt.getPrice()!=null && lskBtc.getPrice() !=null ) {
             BigDecimal lastBtcPriceInUsdt = btcUsdt.getPrice();

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/pac/PacExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/pac/PacExtension.java
@@ -92,11 +92,15 @@ public class PacExtension extends AbstractExtension{
                 return new FixPriceRateSource(rate,preferedFiatCurrency);
             }
             else if ("coinmarketcap".equalsIgnoreCase(rsType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/syscoin/SyscoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/syscoin/SyscoinExtension.java
@@ -88,11 +88,15 @@ public class SyscoinExtension extends AbstractExtension{
                 }
                 return new FixPriceRateSource(rate, preferedFiatCurrency);
             } else if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
-                String preferedFiatCurrency = Currencies.USD;
+                String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
-                    preferedFiatCurrency = st.nextToken().toUpperCase();
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferedFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/zcoin/ZcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/zcoin/ZcoinExtension.java
@@ -59,10 +59,14 @@ public class ZcoinExtension extends AbstractExtension {
             String exchangeType = st.nextToken();
             if ("coinmarketcap".equalsIgnoreCase(exchangeType)) {
                 String preferredFiatCurrency = Currencies.USD;
+                String apiKey = null;
                 if (st.hasMoreTokens()) {
                     preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
-                return new CoinmarketcapRateSource(preferredFiatCurrency);
+                if (st.hasMoreTokens()) {
+                    apiKey = st.nextToken();
+                }
+                return new CoinmarketcapRateSource(apiKey, preferredFiatCurrency);
             }else if ("zcoinfix".equalsIgnoreCase(exchangeType)) {
                 BigDecimal rate = BigDecimal.ZERO;
                 if (st.hasMoreTokens()) {

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -62,6 +62,7 @@
             </ratesource>
             <ratesource prefix="coinmarketcap" name ="CoinMarketCap.com" >
                 <param name="fiatcurrency" />
+                <param name="api_key" />
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LINDA</cryptocurrency>
                 <cryptocurrency>SYS</cryptocurrency>
@@ -835,6 +836,7 @@
         </ratesource>
         <ratesource prefix="binanceRateSource" name ="Binance Rate Source" >
             <param name="fiatCurrency" />
+            <param name="coinmarketcapApiKey"/>
             <cryptocurrency>LSK</cryptocurrency>
             <cryptocurrency>BTC</cryptocurrency>
             <cryptocurrency>LTC</cryptocurrency>

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
@@ -39,6 +39,7 @@ public class CoinmarketcapAPITest {
             api.getTicker(null, "BTC", "USD");
         } catch (HttpStatusIOException e) {
             Assert.assertTrue(e.getHttpBody().contains("API key missing"));
+            return;
         }
         Assert.fail();
     }

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
@@ -5,8 +5,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import si.mazi.rescu.HttpStatusIOException;
 import si.mazi.rescu.RestProxyFactory;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Map;
 
@@ -20,12 +22,22 @@ public class CoinmarketcapAPITest {
         api = RestProxyFactory.createProxy(ICoinmarketcapAPI.class, "https://sandbox-api.coinmarketcap.com");
     }
 
+    @Test
+    public void nullApiKey() throws IOException {
+        try {
+            api.getTicker(null, "BTC", "USD");
+        } catch (HttpStatusIOException e) {
+            Assert.assertTrue(e.getHttpBody().contains("API key missing"));
+        }
+        Assert.fail();
+    }
+
     /**
      * Method getTickerOneIntegerOneStringParametersTest() checks if method getTicker() of the api, with one parameter - id
      * of type string is correctly called and that data is received.
      */
     @Test
-    public void getTickerOneIntegerOneStringParametersTest() {
+    public void getTickerOneIntegerOneStringParametersTest() throws IOException {
         CmcTickerResponse result = api.getTicker(API_KEY, "BTC", "USD");
         Assert.assertNotNull(result);
 
@@ -34,7 +46,7 @@ public class CoinmarketcapAPITest {
     }
 
     @Test
-    public void getTickerDogecoinTest() {
+    public void getTickerDogecoinTest() throws IOException {
         CmcTickerResponse result = api.getTicker(API_KEY, "DOGE", "USD");
         Assert.assertNotNull(result);
 
@@ -52,7 +64,7 @@ public class CoinmarketcapAPITest {
      * of type string is correctly called and that data is received.
      */
     @Test
-    public void getTickerOneIntegerOneNullParametersTest() {
+    public void getTickerOneIntegerOneNullParametersTest() throws IOException {
         CmcTickerResponse result = api.getTicker(API_KEY, "BTC", null);
         Assert.assertNotNull(result);
 
@@ -65,7 +77,7 @@ public class CoinmarketcapAPITest {
      * and fiat of type String is correctly called and that data and quotes has been received.
      */
     @Test
-    public void getQuotesTest() {
+    public void getQuotesTest() throws IOException {
         CmcTickerResponse result = api.getTicker(API_KEY, "BTC", "EUR");
         Assert.assertNotNull(result);
 
@@ -88,7 +100,7 @@ public class CoinmarketcapAPITest {
      * and for particular fiat currency and makes sure that data is provided.
      */
     @Test
-    public void getQuoteByCurrencySymbolAndFiatCurrencyTest() {
+    public void getQuoteByCurrencySymbolAndFiatCurrencyTest() throws IOException {
         String currency = "BTC";
         String fiat = "EUR";
 

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
@@ -23,6 +23,17 @@ public class CoinmarketcapAPITest {
     }
 
     @Test
+    public void jsonTest() throws IOException {
+            Map<String, Map<String, Object>> r = RestProxyFactory.createProxy(TestCoinmarketcapAPI.class, "https://sandbox-api.coinmarketcap.com")
+                .getTicker(API_KEY, "BTC", "USD");
+            Assert.assertEquals(2, r.size());
+            Assert.assertEquals(5, r.get("status").size());
+            Assert.assertNull(r.get("status").get("error_message"));
+            Assert.assertEquals(1, r.get("data").size());
+            Assert.assertNotNull(r.get("data").get("BTC"));
+    }
+
+    @Test
     public void nullApiKey() throws IOException {
         try {
             api.getTicker(null, "BTC", "USD");

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapAPITest.java
@@ -1,134 +1,23 @@
 package com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap;
 
-import com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap.CmcTickerData;
-import com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap.CmcTickerQuote;
-import com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap.CmcTickerResponse;
-import com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap.ICoinmarketcapAPI;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import si.mazi.rescu.RestProxyFactory;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-/**
- * Class CoinmarketcapV2APITest tests method of interface ICoinmarketcapV2API.
- */
 public class CoinmarketcapAPITest {
     private static final Logger log = LoggerFactory.getLogger("batm.master.extensions.CoinmarketcapAPITest");
-
-    private static long currentUnix = System.currentTimeMillis();
-
-    private static final long CACHE_EXPIRY_TIME_DEFAULT = 600;
-
+    public static final String API_KEY = "ba025ccf-579b-40e4-be05-cbcebd83c476";
     private static ICoinmarketcapAPI api;
 
     @BeforeClass
     public static  void setup() {
-        api = RestProxyFactory.createProxy(ICoinmarketcapAPI.class, "https://api.coinmarketcap.com");
-    }
-
-    /**
-     * Method timeTest() tests if enauf time has expired and the listings should be updated.
-     *
-     * @throws InterruptedException
-     */
-    @Test
-    public void timeTest() throws InterruptedException {
-        Assert.assertTrue(true);
-        long recentUnix = System.currentTimeMillis();
-        long diff = recentUnix - currentUnix;
-        long seconds = TimeUnit.SECONDS.convert(diff, TimeUnit.MILLISECONDS) + 3;
-
-        final Map<String, Integer> coinIDs = new HashMap<String, Integer>();
-        long cacheExpiryTime = 2; //2 seconds
-        if(seconds > cacheExpiryTime) {
-            final Map<String, Object> listings = api.getListings();
-            if (listings != null && !listings.isEmpty()) {
-                final List<Object> dataList = (List<Object>) listings.get("data");
-                for (Object dataobject : dataList) {
-                    Map<String, Object> map = (Map<String, Object>) dataobject;
-                    final Integer id = (Integer) map.get("id");
-                    final String symbol = (String) map.get("symbol");
-                    if (!coinIDs.containsKey(symbol) && !coinIDs.containsValue(id)) {
-                        coinIDs.put(symbol, id);
-                    }
-                }
-            }
-        }
-
-        Assert.assertFalse(coinIDs.isEmpty());
-    }
-
-    /**
-     * Method timeNotExpiredTest() tests if enauf time has expired and the listings should be updated.
-     * In this case not enauf time will be provided
-     *
-     * @throws InterruptedException
-     */
-    @Test
-    public void timeNotExpiredTest() throws InterruptedException {
-        Assert.assertTrue(true);
-        long recentUnix = System.currentTimeMillis();
-        long diff = recentUnix - currentUnix;
-        long seconds = TimeUnit.SECONDS.convert(diff, TimeUnit.MILLISECONDS) + 1;
-
-        final Map<String, Integer> coinIDs = new HashMap<String, Integer>();
-        long cacheExpiryTime = 2; //2 seconds
-        if(seconds > CACHE_EXPIRY_TIME_DEFAULT) {
-            final Map<String, Object> listings = api.getListings();
-            if (listings != null && !listings.isEmpty()) {
-                final List<Object> dataList = (List<Object>) listings.get("data");
-                for (Object dataobject : dataList) {
-                    Map<String, Object> map = (Map<String, Object>) dataobject;
-                    final Integer id = (Integer) map.get("id");
-                    final String symbol = (String) map.get("symbol");
-                    if (!coinIDs.containsKey(symbol) && !coinIDs.containsValue(id)) {
-                        coinIDs.put(symbol, id);
-                    }
-                }
-            }
-        }
-
-        Assert.assertTrue(coinIDs.isEmpty());
-    }
-
-    /**
-     * Method timeNotExpiredButCoinIdIsEmptyTest() tests if enauf time has expired and the listings should be updated.
-     * In this case not enauf time will be provided
-     * @throws InterruptedException
-     */
-    @Test
-    public void timeNotExpiredButCoinIdIsEmptyTest() throws InterruptedException {
-        Assert.assertTrue(true);
-        long recentUnix = System.currentTimeMillis();
-        long diff = recentUnix - currentUnix;
-        long seconds = TimeUnit.SECONDS.convert(diff, TimeUnit.MILLISECONDS) + 1;
-
-        final Map<String, Integer> coinIDs = new HashMap<String, Integer>();
-        if(coinIDs.isEmpty() || seconds > CACHE_EXPIRY_TIME_DEFAULT) {
-            final Map<String, Object> listings = api.getListings();
-            if (listings != null && !listings.isEmpty()) {
-                final List<Object> dataList = (List<Object>) listings.get("data");
-                for (Object dataobject : dataList) {
-                    Map<String, Object> map = (Map<String, Object>) dataobject;
-                    final Integer id = (Integer) map.get("id");
-                    final String symbol = (String) map.get("symbol");
-                    if (!coinIDs.containsKey(symbol) && !coinIDs.containsValue(id)) {
-                        coinIDs.put(symbol, id);
-                    }
-                }
-            }
-        }
-
-        Assert.assertFalse(coinIDs.isEmpty());
+        api = RestProxyFactory.createProxy(ICoinmarketcapAPI.class, "https://sandbox-api.coinmarketcap.com");
     }
 
     /**
@@ -137,22 +26,21 @@ public class CoinmarketcapAPITest {
      */
     @Test
     public void getTickerOneIntegerOneStringParametersTest() {
-        CmcTickerResponse result = api.getTicker(1, "USD");
+        CmcTickerResponse result = api.getTicker(API_KEY, "BTC", "USD");
         Assert.assertNotNull(result);
 
-        CmcTickerData data = result.getData();
+        CmcTickerData data = result.getData().get("BTC");
         Assert.assertNotNull(data);
     }
 
     @Test
     public void getTickerDogecoinTest() {
-        Integer dogeCoinId = 74;//coinmarketcap id
-        CmcTickerResponse result = api.getTicker(dogeCoinId, "USD");
+        CmcTickerResponse result = api.getTicker(API_KEY, "DOGE", "USD");
         Assert.assertNotNull(result);
 
-        CmcTickerData data = result.getData();
+        CmcTickerData data = result.getData().get("DOGE");
         Assert.assertNotNull(data);
-        Assert.assertNotNull(data.getQuotes());
+        Assert.assertNotNull(data.getQuote());
 
         //CmcTickerQuote quote = (CmcTickerQuote) data.getQuotes();
         log.info(data.toString());
@@ -165,10 +53,10 @@ public class CoinmarketcapAPITest {
      */
     @Test
     public void getTickerOneIntegerOneNullParametersTest() {
-        CmcTickerResponse result = api.getTicker(1, null);
+        CmcTickerResponse result = api.getTicker(API_KEY, "BTC", null);
         Assert.assertNotNull(result);
 
-        CmcTickerData data = result.getData();
+        CmcTickerData data = result.getData().get("BTC");
         Assert.assertNotNull(data);
     }
 
@@ -178,13 +66,13 @@ public class CoinmarketcapAPITest {
      */
     @Test
     public void getQuotesTest() {
-        CmcTickerResponse result = api.getTicker(1, "EUR");
+        CmcTickerResponse result = api.getTicker(API_KEY, "BTC", "EUR");
         Assert.assertNotNull(result);
 
-        CmcTickerData data = result.getData();
+        CmcTickerData data = result.getData().get("BTC");
         Assert.assertNotNull(data);
 
-        final Map<String, CmcTickerQuote> quotes = data.getQuotes();
+        final Map<String, CmcTickerQuote> quotes = data.getQuote();
         Assert.assertNotNull(quotes);
 
         CmcTickerQuote quote = quotes.get("EUR");
@@ -196,151 +84,24 @@ public class CoinmarketcapAPITest {
     }
 
     /**
-     * Method getListingsTest() calls method getListings() from the api and checks if correct data -
-     * listings for all crypto currencies has been received.
-     */
-    @Test
-    public void getListingsTest() {
-        final Map<String, Object> result = api.getListings();
-        Assert.assertNotNull(result);
-        Assert.assertEquals(3, result.size());
-
-        final Object object = result.get("data");
-        Assert.assertTrue(object instanceof List);
-
-        final List<Object> dataList = (List<Object>)object;
-        Assert.assertNotNull(dataList);
-        Assert.assertFalse(dataList.isEmpty());
-        Assert.assertTrue(dataList.size() > 100);
-
-        final Object dataobject = dataList.get(0);
-        Assert.assertNotNull(object);
-        Assert.assertTrue(dataobject instanceof Map);
-
-        final Map<String, Object> map = (Map<String, Object>)dataobject;
-        Assert.assertNotNull(map);
-
-        final Integer id = (Integer) map.get("id");
-        Assert.assertNotNull(id);
-        Assert.assertEquals(1, id.intValue());
-
-        final String symbol = (String) map.get("symbol");
-        Assert.assertNotNull(symbol);
-        Assert.assertEquals("BTC", symbol);
-
-        final String name = (String) map.get("name");
-        Assert.assertNotNull(name);
-        Assert.assertEquals("Bitcoin", name);
-
-
-        final Object metadataObject = result.get("metadata");
-        Assert.assertTrue(metadataObject instanceof Map);
-
-        final Map<String, Object> metadata = (Map<String, Object>)metadataObject;
-        Assert.assertNotNull(metadata);
-
-        final Integer timestamp = (Integer) metadata.get("timestamp");
-        Assert.assertNotNull(timestamp);
-    }
-
-    /**
-     * Method createCoinIdsTest() tests creation of coinId, which are are received by calling method getListings()
-     * of the api. The listings contain id for each coin, and this ids are used to create map of crypto currency symbol
-     * and its respective id.
-     */
-    @Test
-    public void createCoinIdsTest() {
-        final Map<String, Integer> coinIDs = new HashMap<String, Integer>();
-        final Map<String, Object> listings = api.getListings();
-        final List<Object> dataList = (List<Object>) listings.get("data");
-        Assert.assertNotNull(dataList);
-        Assert.assertFalse(dataList.isEmpty());
-        Assert.assertTrue(dataList.size() > 100);
-
-        for(Object dataobject : dataList) {
-            Map<String, Object> map = (Map<String, Object>)dataobject;
-            final Integer id = (Integer) map.get("id");
-            final String symbol = (String) map.get("symbol");
-            if(!coinIDs.containsKey(symbol) && !coinIDs.containsValue(id)) {
-                coinIDs.put(symbol, id);
-            }
-        }
-
-        Assert.assertFalse(coinIDs.isEmpty());
-    }
-
-    /**
-     * Method getCurrencyIdTest() retrieves currency id for particular crypto currency symbol.
-     * The id is taken by fetching method getListings() of the api.
-     */
-    @Test
-    public void getCurrencyIdTest() {
-        String currency = "ETH";
-
-        final Map<String, Integer> coinIDs = new HashMap<String, Integer>();
-        final Map<String, Object> listings = api.getListings();
-        final List<Object> dataList = (List<Object>) listings.get("data");
-        Assert.assertNotNull(dataList);
-        Assert.assertFalse(dataList.isEmpty());
-        Assert.assertTrue(dataList.size() > 100);
-
-        for(Object dataobject : dataList) {
-            Map<String, Object> map = (Map<String, Object>)dataobject;
-            final Integer id = (Integer) map.get("id");
-            final String symbol = (String) map.get("symbol");
-            if(!coinIDs.containsKey(symbol) && !coinIDs.containsValue(id)) {
-                coinIDs.put(symbol, id);
-            }
-        }
-
-        Assert.assertFalse(coinIDs.isEmpty());
-
-        final Integer id = coinIDs.get(currency);
-        log.info("ETH id = " + id.toString());
-        Assert.assertNotNull(id);
-        Assert.assertEquals(1027, id.intValue());
-    }
-
-    /**
      * Method getQuoteByCurrencySymbolAndFiatCurrencyTest() checks the quotes for particular crypto currency
      * and for particular fiat currency and makes sure that data is provided.
      */
     @Test
     public void getQuoteByCurrencySymbolAndFiatCurrencyTest() {
-        String currency = "ETH";
+        String currency = "BTC";
         String fiat = "EUR";
 
-        final Map<String, Integer> coinIDs = new HashMap<String, Integer>();
-        final Map<String, Object> listings = api.getListings();
-        final List<Object> dataList = (List<Object>) listings.get("data");
-        Assert.assertNotNull(dataList);
-        Assert.assertFalse(dataList.isEmpty());
-        Assert.assertTrue(dataList.size() > 100);
-
-        for(Object dataobject : dataList) {
-            Map<String, Object> map = (Map<String, Object>)dataobject;
-            final Integer id = (Integer) map.get("id");
-            final String symbol = (String) map.get("symbol");
-            if(!coinIDs.containsKey(symbol) && !coinIDs.containsValue(id)) {
-                coinIDs.put(symbol, id);
-            }
-        }
-
-        Assert.assertFalse(coinIDs.isEmpty());
-
-        final Integer id = coinIDs.get(currency);
-        Assert.assertNotNull(id);
-
-        CmcTickerResponse result = api.getTicker(1, fiat);
+        CmcTickerResponse result = api.getTicker(API_KEY, currency, fiat);
         Assert.assertNotNull(result);
 
-        CmcTickerData data = result.getData();
+        CmcTickerData data = result.getData().get(currency);
         Assert.assertNotNull(data);
 
-        final Map<String, CmcTickerQuote> quotes = data.getQuotes();
+        final Map<String, CmcTickerQuote> quotes = data.getQuote();
         Assert.assertNotNull(quotes);
 
-        CmcTickerQuote quote = quotes.get("EUR");
+        CmcTickerQuote quote = quotes.get(fiat);
         Assert.assertNotNull(quote);
 
         BigDecimal price = quote.getPrice();

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapRateSourceTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapRateSourceTest.java
@@ -19,7 +19,7 @@ public class CoinmarketcapRateSourceTest {
      */
     @Test
     public void getExchangeRateLastTest() {
-        CoinmarketcapRateSource rateSource = new CoinmarketcapRateSource("USD");
+        CoinmarketcapRateSource rateSource = new CoinmarketcapRateSource("ba025ccf-579b-40e4-be05-cbcebd83c476", "USD");
 
         final BigDecimal priceUSD = rateSource.getExchangeRateLast("BTC", "USD");
         Assert.assertNotNull(priceUSD);

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapRateSourceTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/CoinmarketcapRateSourceTest.java
@@ -13,13 +13,18 @@ import java.math.BigDecimal;
 public class CoinmarketcapRateSourceTest {
     private static final Logger log = LoggerFactory.getLogger("batm.master.extensions.CoinmarketcapRateSourceTest");
 
+    @Test(expected = NullPointerException.class)
+    public void nullApi() {
+        new CoinmarketcapRateSource(null, "USD");
+    }
+
     /**
      * Unit test method getExchangeRateLastTest() create an object of type CoinmarketcapRateSourceV2
      * with parameter null
      */
     @Test
     public void getExchangeRateLastTest() {
-        CoinmarketcapRateSource rateSource = new CoinmarketcapRateSource("ba025ccf-579b-40e4-be05-cbcebd83c476", "USD");
+        CoinmarketcapRateSource rateSource = new CoinmarketcapRateSource("ce83e9de-db96-4cdd-871d-cf9eb07a8381", "USD");
 
         final BigDecimal priceUSD = rateSource.getExchangeRateLast("BTC", "USD");
         Assert.assertNotNull(priceUSD);

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/TestCoinmarketcapAPI.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/dash/sources/coinmarketcap/TestCoinmarketcapAPI.java
@@ -1,0 +1,39 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2018 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash.sources.coinmarketcap;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A copy of {@link ICoinmarketcapAPI} that returns just map of strings instead of deserialized objects.
+ * Used for tests only
+ */
+@Path("/v1")
+@Produces(MediaType.APPLICATION_JSON)
+public interface TestCoinmarketcapAPI {
+    @GET
+    @Path("/cryptocurrency/quotes/latest")
+    Map<String, Map<String, Object>> getTicker(@HeaderParam("X-CMC_PRO_API_KEY") String apikey, @QueryParam("symbol") String symbol, @QueryParam("convert") String fiatCurrency) throws IOException;
+}


### PR DESCRIPTION
- api key is needed now, see https://pro.coinmarketcap.com/migrate/
- Binance rate source used coinmarketcap too so it needs the key too now