### PR TITLE
BPUB-613 coinbase pro ratesource param description

### DIFF
--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -219,6 +219,7 @@
             <cryptocurrency>LTC</cryptocurrency>
         </exchange>
         <ratesource prefix="coinbasepro" name="Coinbase Pro">
+            <param name="fiatcurrency" />
             <cryptocurrency>BCH</cryptocurrency>
             <cryptocurrency>BTC</cryptocurrency>
             <cryptocurrency>ETH</cryptocurrency>


### PR DESCRIPTION
"hidden for security reasons" was not displayed when a value was configured