### PR TITLE
override purchaseCoins for DV Chain and add sandbox option.

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -106,7 +106,8 @@ public class BitcoinExtension extends AbstractExtension{
             } else if ("dvchain".equalsIgnoreCase(prefix)) {
                 String preferredFiatCurrency = FiatCurrency.USD.getCode();
                 String apiSecret = paramTokenizer.nextToken();
-                return new DVChainExchange(apiSecret, preferredFiatCurrency);
+                boolean useSandbox = Boolean.parseBoolean(paramTokenizer.nextToken());
+                return new DVChainExchange(apiSecret, useSandbox, preferredFiatCurrency);
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/XChangeExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/XChangeExchange.java
@@ -509,6 +509,11 @@ public abstract class XChangeExchange implements IExchangeAdvanced, IRateSourceA
         return null;
     }
 
+
+    public Exchange getExchange() {
+        return exchange;
+    }
+
     @Override
     public BigDecimal calculateSellPrice(String cryptoCurrency, String fiatCurrency, BigDecimal cryptoAmount) {
         if (cryptoCurrency == null || fiatCurrency == null) {


### PR DESCRIPTION
purchasing coins through DV Chain does not currently work because there is no account service for DV Chain. This PR overrides purchaseCoins without the need for the account service.