### PR TITLE
BPUB-649 fix LightningBitcoinPaymentSupport init method

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lightningbitcoin/LightningBitcoinPaymentSupport.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lightningbitcoin/LightningBitcoinPaymentSupport.java
@@ -27,7 +27,7 @@ public class LightningBitcoinPaymentSupport implements IPaymentSupport {
 
     @Override
     public boolean init(IExtensionContext context) {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
this bug randomly stopped other PaymentSupports from being loaded