### PR TITLE
Update DASH extension

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/common/AbstractRPCPaymentSupport.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/common/AbstractRPCPaymentSupport.java
@@ -47,7 +47,7 @@ public abstract class AbstractRPCPaymentSupport implements IPaymentSupport{
     private static final Logger log = LoggerFactory.getLogger("batm.master.RPCPaymentSupport");
 
     private IExtensionContext ctx;
-    private final Map<PaymentRequest, PaymentTracker> requests = new HashMap<>();
+    protected final Map<PaymentRequest, PaymentTracker> requests = new HashMap<>();
     private final Map<RPCClient, IBlockchainWatcher> watchers = new HashMap<>();
 
 
@@ -91,7 +91,7 @@ public abstract class AbstractRPCPaymentSupport implements IPaymentSupport{
 
 
 
-    private RPCClient getClient(IWallet wallet) {
+    protected RPCClient getClient(IWallet wallet) {
         if (wallet != null && (wallet instanceof IRPCWallet)) {
             return ((IRPCWallet) wallet).getClient();
         }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashAddressValidator.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashAddressValidator.java
@@ -17,19 +17,18 @@
  ************************************************************************************/
 package com.generalbytes.batm.server.extensions.extra.dash;
 
-import com.generalbytes.batm.server.coinutil.AddressFormatException;
-import com.generalbytes.batm.server.coinutil.Base58;
-import com.generalbytes.batm.server.extensions.ExtensionsUtil;
 import com.generalbytes.batm.server.extensions.ICryptoAddressValidator;
-
+import com.generalbytes.batm.server.coinutil.Base58;
+import com.generalbytes.batm.server.coinutil.AddressFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DashAddressValidator implements ICryptoAddressValidator {
     private static final Logger log = LoggerFactory.getLogger("batm.master.extensions.DashAddressValidator");
+
     @Override
     public boolean isAddressValid(String address) {
-        if (address.startsWith("X")) {
+        if (address.startsWith("X") || address.startsWith("7")) {
             try {
                 Base58.decodeToBigInteger(address);
                 Base58.decodeChecked(address);
@@ -38,14 +37,13 @@ public class DashAddressValidator implements ICryptoAddressValidator {
                 return false;
             }
             return true;
-        }else{
-            return false;
         }
+        return false;
     }
 
     @Override
     public boolean isPaperWalletSupported() {
-        return true;
+        return false;
     }
 
     @Override

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashDefinition.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashDefinition.java
@@ -1,0 +1,35 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash;
+
+import com.generalbytes.batm.server.extensions.CryptoCurrencyDefinition;
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+import com.generalbytes.batm.server.extensions.payment.IPaymentSupport;
+
+public class DashDefinition extends CryptoCurrencyDefinition{
+    private IPaymentSupport paymentSupport = new DashPaymentSupport();
+
+    public DashDefinition() {
+        super(CryptoCurrency.DASH.getCode(), "Dash", "dash","https://www.dash.org");
+    }
+
+    @Override
+    public IPaymentSupport getPaymentSupport() {
+        return paymentSupport;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashPaperWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashPaperWallet.java
@@ -1,0 +1,69 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash;
+
+import com.generalbytes.batm.server.extensions.IPaperWallet;
+
+public class DashPaperWallet implements IPaperWallet{
+    private String cryptoCurrency;
+    private byte[] content;
+    private String address;
+    private String privateKey;
+    private String message;
+    private String contentType;
+    private String fileExtension;
+
+    public DashPaperWallet(String cryptoCurrency, byte[] content, String address, String privateKey, String message, String contentType, String fileExtension) {
+        this.cryptoCurrency = cryptoCurrency;
+        this.content = content;
+        this.address = address;
+        this.privateKey = privateKey;
+        this.message = message;
+        this.contentType = contentType;
+        this.fileExtension = fileExtension;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public String getFileExtension() {
+        return fileExtension;
+    }
+
+    public String getPrivateKey() {
+        return privateKey;
+    }
+
+    @Override
+    public String getCryptoCurrency() {
+        return cryptoCurrency;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashPaymentSupport.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashPaymentSupport.java
@@ -1,0 +1,176 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash;
+
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+import com.generalbytes.batm.server.extensions.ICryptoAddressValidator;
+import com.generalbytes.batm.server.extensions.extra.common.AbstractRPCPaymentSupport;
+import com.generalbytes.batm.server.extensions.extra.common.RPCClient;
+import com.generalbytes.batm.server.extensions.extra.dash.wallets.dashd.DashRPCWallet;
+import com.generalbytes.batm.server.extensions.extra.dash.test.PRS;
+import com.generalbytes.batm.server.extensions.payment.IPaymentRequestListener;
+import com.generalbytes.batm.server.extensions.payment.PaymentRequest;
+import com.generalbytes.batm.server.extensions.payment.PaymentReceipt;
+import com.generalbytes.batm.server.extensions.extra.dash.wallets.DashRPCClient;
+import com.generalbytes.batm.server.extensions.extra.dash.wallets.DashTransaction;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.MalformedURLException;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DashPaymentSupport extends AbstractRPCPaymentSupport {
+    private static final Logger log = LoggerFactory.getLogger(DashPaymentSupport.class);
+
+    private DashAddressValidator addressValidator = new DashAddressValidator();
+
+    private static final long MAXIMUM_WAIT_FOR_POSSIBLE_REFUND_MILLIS = TimeUnit.DAYS.toMillis(3); // 3 days
+    private static final long MAXIMUM_WATCHING_TIME_MILLIS = TimeUnit.DAYS.toMillis(3); // 3 days (exactly plus Sell Offer Expiration 5-120 minutes)
+    private static final BigDecimal TOLERANCE = new BigDecimal("0.0002"); // Received amount should be  cryptoTotalToSend +- tolerance
+
+    @Override
+    public String getCurrency() {
+        return CryptoCurrency.DASH.getCode();
+    }
+
+    @Override
+    public long getMaximumWatchingTimeMillis() {
+        return MAXIMUM_WATCHING_TIME_MILLIS;
+    }
+
+    @Override
+    public long getMaximumWaitForPossibleRefundInMillis() {
+        return MAXIMUM_WAIT_FOR_POSSIBLE_REFUND_MILLIS;
+    }
+
+    @Override
+    public BigDecimal getTolerance() {
+        return TOLERANCE;
+    }
+
+    @Override
+    public BigDecimal getMinimumNetworkFee(RPCClient client) {
+        return client.getNetworkInfo().relayFee();
+    }
+
+    @Override
+    public ICryptoAddressValidator getAddressValidator() {
+        return addressValidator;
+    }
+
+    @Override
+    public int calculateTransactionSize(int numberOfInputs, int numberOfOutputs) {
+        return (numberOfInputs * 149) + (numberOfOutputs * 34) + 10;
+    }
+
+    @Override
+    public BigDecimal calculateTxFee(int numberOfInputs, int numberOfOutputs, RPCClient client) {
+        final int transactionSize = calculateTransactionSize(numberOfInputs, numberOfOutputs);
+        try {
+            BigDecimal estimate = new BigDecimal(client.getEstimateFee(2));
+            if (BigDecimal.ZERO.compareTo(estimate) == 0 || estimate.compareTo(new BigDecimal("-1")) == 0 ) {
+                return getMinimumNetworkFee(client);
+            }
+            return estimate.divide(new BigDecimal("1000"), RoundingMode.UP).multiply(new BigDecimal(transactionSize));
+        } catch (Exception e) {
+            log.error("", e);
+            return getMinimumNetworkFee(client);
+        }
+    }
+
+    @Override
+    public PaymentReceipt getPaymentReceipt(String paymentAddress) {
+        PaymentReceipt result = new PaymentReceipt(getCurrency(), paymentAddress);
+        for (PaymentRequest paymentRequest : requests.keySet()) {
+            if (paymentRequest.getAddress().equals(paymentAddress)) {
+                switch (paymentRequest.getState()) {
+                    case PaymentRequest.STATE_SEEN_IN_BLOCK_CHAIN:
+                        result.setStatus(PaymentReceipt.STATUS_PAID);
+                        result.setConfidence(PaymentReceipt.CONFIDENCE_SURE);
+                        break;
+                    case PaymentRequest.STATE_SEEN_TRANSACTION:
+                        result.setStatus(PaymentReceipt.STATUS_PAID);
+
+                        //Is it instantsend?
+                        DashRPCClient client = (DashRPCClient)getClient(paymentRequest.getWallet());
+                        DashTransaction dashTx = (DashTransaction)client.getTransaction(paymentRequest.getIncomingTransactionHash());
+                        if(dashTx.instantlock())
+                            result.setConfidence(PaymentReceipt.CONFIDENCE_SURE);
+                        else 
+                            result.setConfidence(PaymentReceipt.CONFIDENCE_NONE);
+                        break;
+                }
+                result.setAmount(paymentRequest.getAmount());
+                result.setTransactionId(paymentRequest.getIncomingTransactionHash());
+            }
+        }
+        return result;
+    }
+
+//   public static void main(String[] args) {
+//       //You need to have node running: i.e.:  dashd -rpcuser=rpcuser -rpcpassword=rpcpassword -rpcport=8332
+//
+//       try {
+//           DashRPCWallet wallet = new DashRPCWallet("http://rpcuser:rpcpassword@localhost:9998", "");
+//           DashPaymentSupport ps = new DashPaymentSupport();
+//           ps.init(null);
+//           PRS spec = new PRS(
+//               ps.getCurrency(),
+//               "Just a test",
+//               60 * 15, //15 min
+//               3,
+//               false,
+//               false,
+//               new BigDecimal("7"),
+//               new BigDecimal("10"),
+//               wallet
+//           );
+//           spec.addOutput("Xfem7sYAMm8uwfrCxqH1ABgsFBDZCWJCXK", new BigDecimal("0.0002"));
+//
+//           PaymentRequest pr = ps.createPaymentRequest(spec);
+//           System.out.println(pr);
+//           pr.setListener(new IPaymentRequestListener() {
+//               @Override
+//               public void stateChanged(PaymentRequest request, int previousState, int newState) {
+//                   System.out.println("stateChanged = " + request + " previousState: " + previousState + " newState: " + newState);
+//               }
+//
+//               @Override
+//               public void numberOfConfirmationsChanged(PaymentRequest request, int numberOfConfirmations, Direction direction) {
+//                   System.out.println("numberOfConfirmationsChanged = " + request + " numberOfConfirmations: " + numberOfConfirmations + " direction: " + direction);
+//               }
+//
+//               @Override
+//               public void refundSent(PaymentRequest request, String toAddress, String cryptoCurrency, BigDecimal amount) {
+//                   System.out.println("refundSent = " + request + " toAddress: " + toAddress + " cryptoCurrency: " + cryptoCurrency + " " + amount);
+//               }
+//           });
+//           System.out.println("Waiting for transfer");
+//
+//           Thread.sleep(20 * 60 * 1000);
+//       } catch (MalformedURLException e) {
+//           e.printStackTrace();
+//       } catch (InterruptedException e) {
+//           e.printStackTrace();
+//       }
+//   }
+
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashWalletGenerator.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/DashWalletGenerator.java
@@ -1,0 +1,81 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash;
+
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+import com.generalbytes.batm.server.extensions.IExtensionContext;
+import com.generalbytes.batm.server.extensions.IPaperWallet;
+import com.generalbytes.batm.server.extensions.IPaperWalletGenerator;
+import com.generalbytes.bitrafael.api.wallet.dash.WalletToolsDASH;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class DashWalletGenerator implements IPaperWalletGenerator {
+
+    private static final Logger log = LoggerFactory.getLogger("batm.master.DashWalletGenerator");
+    private String prefix;
+    private IExtensionContext ctx;
+
+    public DashWalletGenerator(String prefix, IExtensionContext ctx) {
+        this.prefix = prefix;
+        this.ctx = ctx;
+    }
+
+    @Override
+    public IPaperWallet generateWallet(String cryptoCurrency, String oneTimePassword, String userLanguage) {
+        WalletToolsDASH wt = new WalletToolsDASH();
+        String privateKey = wt.generateWalletPrivateKeyWithPrefix(prefix, CryptoCurrency.DASH.getCode());
+        String address = wt.getWalletAddressFromPrivateKey(privateKey, CryptoCurrency.DASH.getCode());
+
+        byte[] content = ctx.createPaperWallet7ZIP(privateKey, address, oneTimePassword, cryptoCurrency);
+
+        //send wallet to customer
+        String messageText = "New wallet " + address + " use your onetime password to open the attachment.";
+        String messageTextLang = readTemplate("/batm/config/template_wallet_" + userLanguage + ".txt");
+        if (messageTextLang != null) {
+            messageText = messageTextLang;
+        }else{
+            String messageTextEN = readTemplate("/batm/config/template_wallet_en.txt");
+            if (messageTextEN != null) {
+                messageText = messageTextEN;
+            }
+        }
+
+        return new DashPaperWallet(cryptoCurrency, content, address, privateKey, messageText,"application/zip", "zip");
+    }
+
+    @SuppressWarnings("all")
+    private String readTemplate(String templateFile) {
+        File f = new File(templateFile);
+        if (f.exists() && f.canRead()) {
+            try {
+                String content = new String(Files.readAllBytes(Paths.get(templateFile)),"UTF-8");
+                return content;
+            } catch (IOException e) {
+                log.error("readTemplate", e);
+            }
+        }
+        return null;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/test/PO.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/test/PO.java
@@ -1,0 +1,58 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash.test;
+
+import com.generalbytes.batm.server.extensions.payment.IPaymentOutput;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class PO implements IPaymentOutput{
+
+    private String address;
+    private BigDecimal amount;
+
+    PO(String address, BigDecimal amount) {
+        this.address = address;
+        this.amount = amount;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void removeAmount(BigDecimal amountToRemove) {
+        amount = amount.subtract(amountToRemove).setScale(8, RoundingMode.HALF_DOWN);
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "PO{" +
+            "address='" + address + '\'' +
+            ", amount=" + amount +
+            '}';
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/test/PRS.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/test/PRS.java
@@ -1,0 +1,198 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash.test;
+
+import com.generalbytes.batm.server.extensions.IWallet;
+import com.generalbytes.batm.server.extensions.payment.IPaymentOutput;
+import com.generalbytes.batm.server.extensions.payment.IPaymentRequestSpecification;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class PRS implements IPaymentRequestSpecification{
+
+    private String cryptoCurrency;
+    private String description;
+    private long validInSeconds;
+    private int removeAfterNumberOfConfirmationsOfIncomingTransaction = -1;
+    private int removeAfterNumberOfConfirmationsOfOutgoingTransaction = -1;
+    private String timeoutRefundAddress;
+    private boolean doNotForward;
+    private boolean doNotForwardOriginalValue;
+    private boolean zeroFixedFee;
+    private BigDecimal minimumMiningFeePerByte;
+    private BigDecimal maximumMiningFeePerByte;
+    private IWallet wallet;
+
+    private List<IPaymentOutput> outputs = new LinkedList<>();
+
+    public PRS(String cryptoCurrency, String description, long validInSeconds, int removeAfterNumberOfConfirmations, boolean doNotForward, boolean zeroFixedFee, BigDecimal minimumMiningFeePerByte, BigDecimal maximumMiningFeePerByte, IWallet wallet) {
+        this.cryptoCurrency = cryptoCurrency;
+        this.description = description;
+        this.validInSeconds = validInSeconds;
+        this.removeAfterNumberOfConfirmationsOfIncomingTransaction = removeAfterNumberOfConfirmations;
+        this.doNotForward = doNotForward;
+        this.doNotForwardOriginalValue = doNotForward;
+        this.zeroFixedFee = zeroFixedFee;
+        this.minimumMiningFeePerByte = (minimumMiningFeePerByte != null) ? minimumMiningFeePerByte : BigDecimal.ZERO;
+        this.maximumMiningFeePerByte = (maximumMiningFeePerByte != null) ? maximumMiningFeePerByte : BigDecimal.ZERO;
+        this.wallet = wallet;
+    }
+
+    public PRS(String cryptoCurrency, String description, long validInSeconds, boolean zeroFixedFee, BigDecimal minimumMiningFeePerByte, BigDecimal maximumMiningFeePerByte, IWallet wallet) {
+        this.cryptoCurrency = cryptoCurrency;
+        this.description = description;
+        this.validInSeconds = validInSeconds;
+        this.zeroFixedFee = zeroFixedFee;
+        this.minimumMiningFeePerByte = (minimumMiningFeePerByte != null) ? minimumMiningFeePerByte : BigDecimal.ZERO;
+        this.maximumMiningFeePerByte = (maximumMiningFeePerByte != null) ? maximumMiningFeePerByte : BigDecimal.ZERO;
+        this.wallet = wallet;
+    }
+
+    public BigDecimal getOptimalMiningFee(BigDecimal feeCalculated, int transactionSize) {
+        BigDecimal size = new BigDecimal(Integer.valueOf(transactionSize).toString());
+        BigDecimal feeMinimum = minimumMiningFeePerByte.multiply(size).movePointLeft(8);
+        BigDecimal feeMaximum = maximumMiningFeePerByte.multiply(size).movePointLeft(8);
+        BigDecimal fee = (feeMinimum.compareTo(feeCalculated) > 0) ? feeMinimum : feeCalculated;
+        if (feeMaximum.compareTo(BigDecimal.ZERO) > 0 && feeMaximum.compareTo(fee) < 0) {
+            fee = feeMaximum;
+        }
+        return fee.setScale(8, BigDecimal.ROUND_HALF_UP);
+    }
+
+    public void addOutput(String address, BigDecimal amount) {
+        outputs.add(new PO(address, amount));
+        if (outputs.size() > 1) {
+            doNotForward = false; // must be forwarded because it has multiple outputs.
+        }
+    }
+
+    public List<IPaymentOutput> getOutputs() {
+        return outputs;
+    }
+
+    public BigDecimal getTotal() {
+        BigDecimal total = BigDecimal.ZERO;
+        for (IPaymentOutput paymentOutput : outputs) {
+            total = total.add(paymentOutput.getAmount());
+        }
+        return total;
+    }
+
+    public void removeTotalAmountFromOutputs(BigDecimal totalAmountToRemove) {
+        BigDecimal totalAmount = getTotal();
+        BigDecimal removalRatio = BigDecimal.ONE.subtract(totalAmount.subtract(totalAmountToRemove).divide(totalAmount, 16, BigDecimal.ROUND_HALF_UP));
+        for (IPaymentOutput paymentOutput : outputs) {
+            paymentOutput.removeAmount(paymentOutput.getAmount().multiply(removalRatio));
+        }
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public long getValidInSeconds() {
+        return validInSeconds;
+    }
+
+    public int getRemoveAfterNumberOfConfirmationsOfOutgoingTransaction() {
+        return removeAfterNumberOfConfirmationsOfOutgoingTransaction;
+    }
+
+    public void setRemoveAfterNumberOfConfirmationsOfOutgoingTransaction(int removeAfterNumberOfConfirmationsOfOutgoingTransaction) {
+        this.removeAfterNumberOfConfirmationsOfOutgoingTransaction = removeAfterNumberOfConfirmationsOfOutgoingTransaction;
+    }
+
+    public int getRemoveAfterNumberOfConfirmationsOfIncomingTransaction() {
+        return removeAfterNumberOfConfirmationsOfIncomingTransaction;
+    }
+
+    public void setRemoveAfterNumberOfConfirmationsOfIncomingTransaction(int removeAfterNumberOfConfirmationsOfIncomingTransaction) {
+        this.removeAfterNumberOfConfirmationsOfIncomingTransaction = removeAfterNumberOfConfirmationsOfIncomingTransaction;
+    }
+
+    public void setTimeoutRefundAddress(String timeoutRefundAddress) {
+        this.timeoutRefundAddress = timeoutRefundAddress;
+    }
+
+    public String getTimeoutRefundAddress() {
+        return timeoutRefundAddress;
+    }
+
+    public boolean isDoNotForward() {
+        return doNotForward;
+    }
+
+    public void setDoNotForward(boolean doNotForward) {
+        this.doNotForward = doNotForward;
+        this.doNotForwardOriginalValue = doNotForward;
+    }
+
+    public boolean isZeroFixedFee() {
+        return zeroFixedFee;
+    }
+
+    public void optimize() {
+        Map<String, BigDecimal> sums = new LinkedHashMap<>();
+        for (IPaymentOutput output : outputs) {
+            BigDecimal amount = sums.get(output.getAddress());
+            if (amount != null) {
+                sums.put(output.getAddress(), amount.add(output.getAmount()));
+            } else {
+                sums.put(output.getAddress(), output.getAmount());
+            }
+        }
+        outputs.clear();
+        for (Map.Entry<String, BigDecimal> entry : sums.entrySet()) {
+            addOutput(entry.getKey(), entry.getValue());
+        }
+        if (doNotForwardOriginalValue && outputs.size() == 1) {
+            doNotForward = true;
+        }
+    }
+
+    @Override
+    public IWallet getWallet() {
+        return wallet;
+    }
+
+    @Override
+    public String toString() {
+        return "PRS{" +
+                "description='" + description + '\'' +
+                ", cryptoCurrency=" + cryptoCurrency +
+                ", validInSeconds=" + validInSeconds +
+                ", removeAfterNumberOfConfirmationsOfIncomingTransaction=" + removeAfterNumberOfConfirmationsOfIncomingTransaction +
+                ", removeAfterNumberOfConfirmationsOfOutgoingTransaction=" + removeAfterNumberOfConfirmationsOfOutgoingTransaction +
+                ", timeoutRefundAddress='" + timeoutRefundAddress + '\'' +
+                ", doNotForward=" + doNotForward +
+                ", doNotForwardOriginalValue=" + doNotForwardOriginalValue +
+                ", outputs=" + outputs +
+                ", zeroFixedFee=" + zeroFixedFee +
+                ", minimumMiningFeePerByte=" + minimumMiningFeePerByte +
+                ", maximumMiningFeePerByte=" + maximumMiningFeePerByte +
+                '}';
+    }
+
+    public String getCryptoCurrency() {
+        return cryptoCurrency;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/DashRPCClient.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/DashRPCClient.java
@@ -1,0 +1,158 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash.wallets;
+
+import java.net.MalformedURLException;
+import java.util.Map;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Date;
+
+import wf.bitcoin.javabitcoindrpcclient.GenericRpcException;
+import com.generalbytes.batm.server.extensions.extra.dash.wallets.MapWrapper;
+import java.util.logging.Logger;
+
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+import com.generalbytes.batm.server.extensions.extra.common.RPCClient;
+
+public class DashRPCClient extends RPCClient {
+
+    private static final Logger logger = Logger.getLogger(DashRPCClient.class.getCanonicalName());
+
+
+    public DashRPCClient(String rpcUrl) throws MalformedURLException {
+        super(CryptoCurrency.DASH.getCode(), rpcUrl);
+    }
+
+    @Override
+    public Transaction getTransaction(String txId) {
+        return new DashTransactionWrapper((Map) query("gettransaction", txId));
+    }
+
+    @SuppressWarnings("serial")
+    class DashTransactionWrapper extends MapWrapper implements DashTransaction, Serializable {
+
+        @SuppressWarnings("rawtypes")
+        public DashTransactionWrapper(Map m) {
+            super(m);
+        }
+
+        @Override
+        public String account() {
+            return mapStr(m, "account");
+        }
+
+        @Override
+        public String address() {
+            return mapStr(m, "address");
+        }
+
+        @Override
+        public String category() {
+            return mapStr(m, "category");
+        }
+
+        @Override
+        public BigDecimal amount() {
+            return mapBigDecimal(m, "amount");
+        }
+
+        @Override
+        public BigDecimal fee() {
+            return mapBigDecimal(m, "fee");
+        }
+
+        @Override
+        public int confirmations() {
+            return mapInt(m, "confirmations");
+        }
+
+        @Override
+        public String blockHash() {
+            return mapStr(m, "blockhash");
+        }
+
+        @Override
+        public int blockIndex() {
+            return mapInt(m, "blockindex");
+        }
+
+        @Override
+        public Date blockTime() {
+            return mapCTime(m, "blocktime");
+        }
+
+        @Override
+        public String txId() {
+            return mapStr(m, "txid");
+        }
+
+        @Override
+        public Date time() {
+            return mapCTime(m, "time");
+        }
+
+        @Override
+        public Date timeReceived() {
+            return mapCTime(m, "timereceived");
+        }
+
+        @Override
+        public String comment() {
+           return mapStr(m, "comment");
+        }
+
+        @Override
+        public String commentTo() {
+            return mapStr(m, "to");
+        }
+
+        @Override
+        public boolean generated() {
+            return mapBool(m, "generated");
+        }
+
+        @Override
+        public boolean instantlock() {
+            return mapBool(m, "instantlock");
+        }
+
+        @Override
+        public boolean instantlock_internal() {
+            return mapBool(m, "instantlock_internal");
+        }
+
+        private RawTransaction raw = null;
+
+        @Override
+        public RawTransaction raw() {
+        if (raw == null)
+            try {
+                raw = getRawTransaction(txId());
+            } catch (GenericRpcException ex) {
+                logger.warning(ex.getMessage());
+            }
+            return raw;
+        }
+
+        @Override
+        public String toString() {
+            return m.toString();
+        }
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/DashTransaction.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/DashTransaction.java
@@ -1,0 +1,25 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash.wallets;
+
+import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient.Transaction;
+
+public interface DashTransaction extends Transaction {
+    boolean instantlock();
+    boolean instantlock_internal();
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/MapWrapper.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/MapWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * Bitcoin-JSON-RPC-Client License
+ * 
+ * Copyright (c) 2013, Mikhail Yevchenko.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 
+ * Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ * ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH
+ * THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.generalbytes.batm.server.extensions.extra.dash.wallets;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.Map;
+
+import wf.bitcoin.krotjson.HexCoder;
+
+/**
+ *
+ * @author Mikhail Yevchenko m.ṥῥẚɱ.ѓѐḿởύḙ@azazar.com
+ */
+class MapWrapper {
+
+  public final Map m;
+
+  public MapWrapper(Map m) {
+    this.m = m;
+  }
+
+  public Boolean mapBool(String key) {
+    return mapBool(m, key);
+  }
+
+  public Integer mapInt(String key) {
+    return mapInt(m, key);
+  }
+
+  public Long mapLong(String key) {
+    return mapLong(m, key);
+  }
+
+  public String mapStr(String key) {
+    return mapStr(m, key);
+  }
+
+  public Date mapCTime(String key) {
+    return mapCTime(m, key);
+  }
+
+  public BigDecimal mapBigDecimal(String key) {
+    return mapBigDecimal(m, key);
+  }
+
+  public byte[] mapHex(String key) {
+    return mapHex(m, key);
+  }
+
+  public static Boolean mapBool(Map m, String key) {
+    Object val = m.get(key);
+    return val instanceof Boolean ? (Boolean) val : Boolean.FALSE;
+  }
+
+  public static BigDecimal mapBigDecimal(Map m, String key) {
+    Object val = m.get(key);
+    return val instanceof BigDecimal ? (BigDecimal) val : new BigDecimal((String) val);
+  }
+
+  public static Integer mapInt(Map m, String key) {
+    Object val = m.get(key);
+    return val instanceof Number ? ((Number) val).intValue() : null;
+  }
+
+  public static Long mapLong(Map m, String key) {
+    Object val = m.get(key);
+    return val instanceof Number ? ((Number) val).longValue() : null;
+  }
+
+  public static String mapStr(Map m, String key) {
+    Object v = m.get(key);
+    return v == null ? null : String.valueOf(v);
+  }
+
+  public static Date mapCTime(Map m, String key) {
+    Object v = m.get(key);
+    return v == null ? null : new Date(mapLong(m, key) * 1000);
+  }
+
+  public static byte[] mapHex(Map m, String key) {
+    Object v = m.get(key);
+    return v == null ? null : HexCoder.decode((String) v);
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(m);
+  }
+
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/dashd/DashRPCWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/dashd/DashRPCWallet.java
@@ -18,9 +18,12 @@
 package com.generalbytes.batm.server.extensions.extra.dash.wallets.dashd;
 
 import wf.bitcoin.javabitcoindrpcclient.BitcoinRPCException;
-import wf.bitcoin.javabitcoindrpcclient.BitcoinJSONRPCClient;
 import com.generalbytes.batm.common.currencies.CryptoCurrency;
 import com.generalbytes.batm.server.extensions.IWallet;
+import com.generalbytes.batm.server.extensions.extra.common.IRPCWallet;
+import com.generalbytes.batm.server.extensions.extra.common.RPCClient;
+import com.generalbytes.batm.server.extensions.extra.dash.wallets.DashRPCClient;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,11 +33,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class DashRPCWallet implements IWallet{
+public class DashRPCWallet implements IWallet, IRPCWallet {
     private static final Logger log = LoggerFactory.getLogger(DashRPCWallet.class);
     private static final String CRYPTO_CURRENCY = CryptoCurrency.DASH.getCode();
 
-    public DashRPCWallet(String rpcURL, String accountName) {
+    public DashRPCWallet(String rpcURL, String accountName) throws MalformedURLException {
         this.rpcURL = rpcURL;
         this.accountName = accountName;
     }
@@ -107,12 +110,17 @@ public class DashRPCWallet implements IWallet{
         }
     }
 
-    private BitcoinJSONRPCClient getClient(String rpcURL) {
+    private DashRPCClient getClient(String rpcURL) {
         try {
-            return new BitcoinJSONRPCClient(rpcURL);
+            return new DashRPCClient(rpcURL);
         } catch (MalformedURLException e) {
             log.error("Error", e);
         }
         return null;
+    }
+
+    @Override
+    public RPCClient getClient() {
+        return getClient(rpcURL);
     }
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/dashd/DashUniqueAddressRPCWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/dash/wallets/dashd/DashUniqueAddressRPCWallet.java
@@ -1,0 +1,33 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.dash.wallets.dashd;
+
+import java.net.MalformedURLException;
+
+import com.generalbytes.batm.server.extensions.IGeneratesNewDepositCryptoAddress;
+
+public class DashUniqueAddressRPCWallet extends DashRPCWallet implements IGeneratesNewDepositCryptoAddress {
+    public DashUniqueAddressRPCWallet(String rpcURL, String accountName) throws MalformedURLException {
+        super(rpcURL, accountName);
+    }
+
+    @Override
+    public String generateNewDepositCryptoAddress(String cryptoCurrency, String label) {
+        return getCryptoAddress(cryptoCurrency);
+    }
+}

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -625,6 +625,16 @@
             <param name="accountname" />
             <cryptocurrency>DASH</cryptocurrency>
         </wallet>
+        <wallet prefix="dashdnoforward" name="Dash Core - dashd (no forward)" >
+            <param name="protocol" />
+            <param name="user" />
+            <param name="password" />
+            <param name="host" />
+            <param name="port" />
+            <param name="accountname" />
+            <cryptocurrency>DASH</cryptocurrency>
+            <help>For DASH SELL this is the only supported wallet. This variant generates new addresses for each transaction and does not forward payments from temporary address</help>
+        </wallet>
         <ratesource prefix="cddash" name="Cryptodiggers" >
             <cryptocurrency>DASH</cryptocurrency>
         </ratesource>


### PR DESCRIPTION
* Support InstantSend via dashd RPC
* Support X (P2PKH) and 7 (P2SH) address prefixes

**Explanation of Changes:**
The BitcoinCash extension was used as a template while pulling existing code that was present as part of the Dash extension.

Since Dash has extra fields in the `gettransaction` and `getrawtransaction` commands that are not exposed by the Bitcoin-JSON-RPC-Client library, these classes and interfaces were added:  `DashTransaction`, `DashTransactionWrapper`, `MapWrapper` (duplicated from BitcoinJsonRPC but cause it is a private class) and `DashRPCClient`.

getPaymentReceipt was overriden from AbstractRPCPaymentSupport to add `CONFIDENCE_SURE` if the transaction is locked by the InstantSend mechanism.  I don't like the way this was done, but it seems like some changes to AbstractRPCPaymentSupport will be required regardless.  In this PR I set the field `requests` as protected and made the `getClient` method protected also.  The reason for this is that we need to get use the `DashRPCClient` to call `getTransaction`, but the client is retrieved from the wallet, which is stored in the requests.  I thought of simply creating a new DashRPCClient, but the `DashPaymentSupport` object doesn't know the RPC URL.

Testing was successful with these commands:
/gradlew :server_extensions_test:install
./server_extensions_test/build/install/server_extensions_test/bin/server_extensions_test

In DashPaymentSupport.java, there is a main method that is commented out.  I tried this test also, but I may not have set up my `dashd` correctly or something nothing seemed to happen when I ran this test and sent coins to the address.

Let us know what needs to be changed.
