### PR TITLE
BPUB-1164 binance exchange

### DIFF
--- a/dependencyChecksums.txt
+++ b/dependencyChecksums.txt
@@ -58,6 +58,7 @@ verifyModule 'org.dashj:dashj-bls:0.15.2.20190416:8250ba224d55b826f8cea8162c99c5
 verifyModule 'org.dashj:dashj-core:0.15.2.20190416:b02021654d70435c9d90a3480e1e7ae2c022bcb1b6e1513e83e347f6d5cdbccf'
 verifyModule 'org.java-websocket:Java-WebSocket:1.3.8:64d38c6b4d6c9e830be6820d408caa02d1217e59e8bf34198cc22bd23429fa48'
 verifyModule 'org.json:json:20180130:3eddf6d9d50e770650e62abe62885f4393aa911430ecde73ebafb1ffd2cfad16'
+verifyModule 'org.knowm.xchange:xchange-binance:4.4.0:2dafca4a1d3abc6f8d43d1e346429cf54c3b7b249d8ce1ba0b7a0e504cb2e69e'
 verifyModule 'org.knowm.xchange:xchange-bitfinex:4.4.0:79134d5a58810e9b18468222b0f2288d49b70e2f18e72a7ba0c8c2efced848e0'
 verifyModule 'org.knowm.xchange:xchange-bittrex:4.4.0:fc17f1040e77b1c5ac55a1ecd19922bfbf7783e8062c6d24df6aa56f812967d2'
 verifyModule 'org.knowm.xchange:xchange-coinbasepro:4.4.0:3d4a11d889c55aa6c33f97ab7c5591ca95689bcac7aaec3ab78066cf92237514'

--- a/server_extensions_extra/build.gradle
+++ b/server_extensions_extra/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     compile(group: 'com.google.guava', name: 'guava', version: '27.0.1-android')
     compile(group: 'com.google.zxing', name: 'core', version: '2.3.0')
     compile(group: 'org.knowm.xchange', name: 'xchange-bitfinex', version: '4.4.0')
+    compile(group: 'org.knowm.xchange', name: 'xchange-binance', version: '4.4.0')
     compile(group: 'org.knowm.xchange', name: 'xchange-itbit', version: '4.4.0')
     compile(group: 'org.knowm.xchange', name: 'xchange-bittrex', version: '4.4.0')
     compile(group: 'org.knowm.xchange', name: 'xchange-hitbtc', version: '4.4.0')

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -21,6 +21,9 @@ import com.generalbytes.batm.common.currencies.CryptoCurrency;
 import com.generalbytes.batm.common.currencies.FiatCurrency;
 import com.generalbytes.batm.server.extensions.*;
 import com.generalbytes.batm.server.extensions.FixPriceRateSource;
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance.BinanceComExchange;
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance.BinanceJerseyExchange;
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance.BinanceUsExchange;
 import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bitfinex.BitfinexExchange;
 import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bitflyer.BitFlyerExchange;
 import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.BittrexExchange;
@@ -140,6 +143,34 @@ public class BitcoinExtension extends AbstractExtension {
                     preferredFiatCurrency = paramTokenizer.nextToken().toUpperCase();
                 }
                 return new EnigmaExchange(username, password, preferredFiatCurrency);
+
+            } else if ("binancecom".equalsIgnoreCase(prefix)) {
+                String preferredFiatCurrency = FiatCurrency.USD.getCode();
+                String apikey = paramTokenizer.nextToken();
+                String secretKey = paramTokenizer.nextToken();
+                if (paramTokenizer.hasMoreTokens()) {
+                    preferredFiatCurrency = paramTokenizer.nextToken().toUpperCase();
+                }
+                return new BinanceComExchange(apikey, secretKey, preferredFiatCurrency);
+
+            } else if ("binanceus".equalsIgnoreCase(prefix)) {
+                String preferredFiatCurrency = FiatCurrency.USD.getCode();
+                String apikey = paramTokenizer.nextToken();
+                String secretKey = paramTokenizer.nextToken();
+                if (paramTokenizer.hasMoreTokens()) {
+                    preferredFiatCurrency = paramTokenizer.nextToken().toUpperCase();
+                }
+                return new BinanceUsExchange(apikey, secretKey, preferredFiatCurrency);
+
+            } else if ("binancejersey".equalsIgnoreCase(prefix)) {
+                String preferredFiatCurrency = FiatCurrency.EUR.getCode();
+                String apikey = paramTokenizer.nextToken();
+                String secretKey = paramTokenizer.nextToken();
+                if (paramTokenizer.hasMoreTokens()) {
+                    preferredFiatCurrency = paramTokenizer.nextToken().toUpperCase();
+                }
+                return new BinanceJerseyExchange(apikey, secretKey, preferredFiatCurrency);
+
             }
         }
         return null;
@@ -345,6 +376,28 @@ public class BitcoinExtension extends AbstractExtension {
                     preferredFiatCurrency = st.nextToken().toUpperCase();
                 }
                 return new BitKubRateSource(preferredFiatCurrency);
+
+            } else if ("binancecom".equalsIgnoreCase(rsType)) {
+                String preferredFiatCurrency = FiatCurrency.USD.getCode();
+                if (st.hasMoreTokens()) {
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
+                }
+                return new BinanceComExchange(preferredFiatCurrency);
+
+            } else if ("binanceus".equalsIgnoreCase(rsType)) {
+                String preferredFiatCurrency = FiatCurrency.USD.getCode();
+                if (st.hasMoreTokens()) {
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
+                }
+                return new BinanceUsExchange(preferredFiatCurrency);
+
+            } else if ("binancejersey".equalsIgnoreCase(rsType)) {
+                String preferredFiatCurrency = FiatCurrency.EUR.getCode();
+                if (st.hasMoreTokens()) {
+                    preferredFiatCurrency = st.nextToken().toUpperCase();
+                }
+                return new BinanceJerseyExchange(preferredFiatCurrency);
+
             }
         }
         return null;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceComExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceComExchange.java
@@ -1,0 +1,69 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance;
+
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BinanceComExchange extends BinanceExchange {
+    private static final String SSL_URI = "https://api.binance.com/";
+
+    public BinanceComExchange(String preferredFiatCurrency) {
+        super(preferredFiatCurrency, SSL_URI);
+    }
+
+    public BinanceComExchange(String key, String secret, String preferredFiatCurrency) {
+        super(key, secret, preferredFiatCurrency, SSL_URI);
+    }
+
+    @Override
+    public Set<String> getFiatCurrencies() {
+        Set<String> fiatCurrencies = new HashSet<>();
+        return fiatCurrencies;
+    }
+
+    @Override
+    public Set<String> getCryptoCurrencies() {
+        Set<String> cryptoCurrencies = new HashSet<>();
+        cryptoCurrencies.add(CryptoCurrency.BAT.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BCH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BNB.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BTC.getCode());
+        cryptoCurrencies.add(CryptoCurrency.CLOAK.getCode());
+        cryptoCurrencies.add(CryptoCurrency.DASH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.DOGE.getCode());
+        cryptoCurrencies.add(CryptoCurrency.ETH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.GRS.getCode());
+        cryptoCurrencies.add(CryptoCurrency.KMD.getCode());
+        cryptoCurrencies.add(CryptoCurrency.LSK.getCode());
+        cryptoCurrencies.add(CryptoCurrency.LTC.getCode());
+        cryptoCurrencies.add(CryptoCurrency.NULS.getCode());
+        cryptoCurrencies.add(CryptoCurrency.REP.getCode());
+        cryptoCurrencies.add(CryptoCurrency.SYS.getCode());
+        cryptoCurrencies.add(CryptoCurrency.TRX.getCode());
+        cryptoCurrencies.add(CryptoCurrency.USDS.getCode());
+        cryptoCurrencies.add(CryptoCurrency.USDT.getCode());
+        cryptoCurrencies.add(CryptoCurrency.VIA.getCode());
+        cryptoCurrencies.add(CryptoCurrency.XMR.getCode());
+        cryptoCurrencies.add(CryptoCurrency.XRP.getCode());
+        cryptoCurrencies.add(CryptoCurrency.XZC.getCode());
+        return cryptoCurrencies;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceExchange.java
@@ -1,0 +1,62 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance;
+
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.XChangeExchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.Wallet;
+
+public abstract class BinanceExchange extends XChangeExchange {
+
+    public BinanceExchange(String preferredFiatCurrency, String sslUri) {
+        super(getDefaultSpecification(sslUri), preferredFiatCurrency);
+    }
+
+    public BinanceExchange(String key, String secret, String preferredFiatCurrency, String sslUri) {
+        super(getSpecification(key, secret, sslUri), preferredFiatCurrency);
+    }
+
+    private static ExchangeSpecification getDefaultSpecification(String sslUri) {
+        ExchangeSpecification spec = new org.knowm.xchange.binance.BinanceExchange().getDefaultExchangeSpecification();
+        spec.setSslUri(sslUri);
+        return spec;
+    }
+
+    private static ExchangeSpecification getSpecification(String key, String secret, String sslUri) {
+        ExchangeSpecification spec = getDefaultSpecification(sslUri);
+        spec.setApiKey(key);
+        spec.setSecretKey(secret);
+        return spec;
+    }
+
+    @Override
+    protected boolean isWithdrawSuccessful(String result) {
+        return true;
+    }
+
+    @Override
+    protected double getAllowedCallsPerSecond() {
+        return 10;
+    }
+
+    @Override
+    public Wallet getWallet(AccountInfo accountInfo, String currency) {
+        return accountInfo.getWallet();
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceJerseyExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceJerseyExchange.java
@@ -1,0 +1,55 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance;
+
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+import com.generalbytes.batm.common.currencies.FiatCurrency;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BinanceJerseyExchange extends BinanceExchange {
+    private static final String SSL_URI = "https://api.binance.je/";
+
+    public BinanceJerseyExchange(String preferredFiatCurrency) {
+        super(preferredFiatCurrency, SSL_URI);
+    }
+
+    public BinanceJerseyExchange(String key, String secret, String preferredFiatCurrency) {
+        super(key, secret, preferredFiatCurrency, SSL_URI);
+    }
+
+    @Override
+    public Set<String> getFiatCurrencies() {
+        Set<String> fiatCurrencies = new HashSet<>();
+        fiatCurrencies.add(FiatCurrency.EUR.getCode());
+        fiatCurrencies.add(FiatCurrency.GBP.getCode());
+        return fiatCurrencies;
+    }
+
+    @Override
+    public Set<String> getCryptoCurrencies() {
+        Set<String> cryptoCurrencies = new HashSet<>();
+        cryptoCurrencies.add(CryptoCurrency.BCH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BNB.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BTC.getCode());
+        cryptoCurrencies.add(CryptoCurrency.ETH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.LTC.getCode());
+        return cryptoCurrencies;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceUsExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceUsExchange.java
@@ -1,0 +1,60 @@
+/*************************************************************************************
+ * Copyright (C) 2014-2019 GENERAL BYTES s.r.o. All rights reserved.
+ *
+ * This software may be distributed and modified under the terms of the GNU
+ * General Public License version 2 (GPL2) as published by the Free Software
+ * Foundation and appearing in the file GPL2.TXT included in the packaging of
+ * this file. Please note that GPL2 Section 2[b] requires that all works based
+ * on this software must also be made publicly available under the terms of
+ * the GPL2 ("Copyleft").
+ *
+ * Contact information
+ * -------------------
+ *
+ * GENERAL BYTES s.r.o.
+ * Web      :  http://www.generalbytes.com
+ *
+ ************************************************************************************/
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance;
+
+import com.generalbytes.batm.common.currencies.CryptoCurrency;
+import com.generalbytes.batm.common.currencies.FiatCurrency;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BinanceUsExchange extends BinanceExchange {
+    private static final String SSL_URI = "https://api.binance.us/";
+
+    public BinanceUsExchange(String preferredFiatCurrency) {
+        super(preferredFiatCurrency, SSL_URI);
+    }
+
+    public BinanceUsExchange(String key, String secret, String preferredFiatCurrency) {
+        super(key, secret, preferredFiatCurrency, SSL_URI);
+    }
+
+    @Override
+    public Set<String> getFiatCurrencies() {
+        Set<String> fiatCurrencies = new HashSet<>();
+        fiatCurrencies.add(FiatCurrency.USD.getCode());
+        return fiatCurrencies;
+    }
+
+
+    @Override
+    public Set<String> getCryptoCurrencies() {
+        Set<String> cryptoCurrencies = new HashSet<>();
+        cryptoCurrencies.add(CryptoCurrency.BAT.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BCH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BNB.getCode());
+        cryptoCurrencies.add(CryptoCurrency.BTC.getCode());
+        cryptoCurrencies.add(CryptoCurrency.DASH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.DOGE.getCode());
+        cryptoCurrencies.add(CryptoCurrency.ETH.getCode());
+        cryptoCurrencies.add(CryptoCurrency.LTC.getCode());
+        cryptoCurrencies.add(CryptoCurrency.USDT.getCode());
+        cryptoCurrencies.add(CryptoCurrency.XRP.getCode());
+        return cryptoCurrencies;
+    }
+}

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -439,6 +439,85 @@
             <cryptocurrency>XSG</cryptocurrency>
             <cryptocurrency>XZC</cryptocurrency>
         </ratesource>
+        <exchange prefix="binancecom" name="Binance.com">
+            <param name="apikey"/>
+            <param name="secretkey"/>
+            <param name="fiatcurrency"/>
+            <cryptocurrency>BAT</cryptocurrency>
+            <cryptocurrency>BCH</cryptocurrency>
+            <cryptocurrency>BNB</cryptocurrency>
+            <cryptocurrency>BTC</cryptocurrency>
+            <cryptocurrency>CLOAK</cryptocurrency>
+            <cryptocurrency>DASH</cryptocurrency>
+            <cryptocurrency>DOGE</cryptocurrency>
+            <cryptocurrency>ETH</cryptocurrency>
+            <cryptocurrency>GRS</cryptocurrency>
+            <cryptocurrency>KMD</cryptocurrency>
+            <cryptocurrency>LSK</cryptocurrency>
+            <cryptocurrency>LTC</cryptocurrency>
+            <cryptocurrency>NULS</cryptocurrency>
+            <cryptocurrency>REP</cryptocurrency>
+            <cryptocurrency>SYS</cryptocurrency>
+            <cryptocurrency>TRX</cryptocurrency>
+            <cryptocurrency>USDS</cryptocurrency>
+            <cryptocurrency>USDT</cryptocurrency>
+            <cryptocurrency>VIA</cryptocurrency>
+            <cryptocurrency>XMR</cryptocurrency>
+            <cryptocurrency>XRP</cryptocurrency>
+            <cryptocurrency>XZC</cryptocurrency>
+        </exchange>
+<!--    No fiat on binance.com - use a stablecoin as fiat in future? -->
+<!--        <ratesource prefix="binancecom" name="Binance.com">-->
+<!--            <param name="fiatcurrency" />-->
+<!--            <cryptocurrency>BTC</cryptocurrency>-->
+<!--        </ratesource>-->
+        <exchange prefix="binanceus" name="Binance US">
+            <param name="apikey"/>
+            <param name="secretkey"/>
+            <param name="fiatcurrency"/>
+            <cryptocurrency>BAT</cryptocurrency>
+            <cryptocurrency>BCH</cryptocurrency>
+            <cryptocurrency>BNB</cryptocurrency>
+            <cryptocurrency>BTC</cryptocurrency>
+            <cryptocurrency>DASH</cryptocurrency>
+            <cryptocurrency>DOGE</cryptocurrency>
+            <cryptocurrency>ETH</cryptocurrency>
+            <cryptocurrency>LTC</cryptocurrency>
+            <cryptocurrency>USDT</cryptocurrency>
+            <cryptocurrency>XRP</cryptocurrency>
+        </exchange>
+        <ratesource prefix="binanceus" name="Binance US">
+            <param name="fiatcurrency" />
+            <cryptocurrency>BAT</cryptocurrency>
+            <cryptocurrency>BCH</cryptocurrency>
+            <cryptocurrency>BNB</cryptocurrency>
+            <cryptocurrency>BTC</cryptocurrency>
+            <cryptocurrency>DASH</cryptocurrency>
+            <cryptocurrency>DOGE</cryptocurrency>
+            <cryptocurrency>ETH</cryptocurrency>
+            <cryptocurrency>LTC</cryptocurrency>
+            <cryptocurrency>USDT</cryptocurrency>
+            <cryptocurrency>XRP</cryptocurrency>
+        </ratesource>
+        <exchange prefix="binancejersey" name="Binance Jersey">
+            <param name="apikey"/>
+            <param name="secretkey"/>
+            <param name="fiatcurrency"/>
+            <cryptocurrency>BCH</cryptocurrency>
+            <cryptocurrency>BNB</cryptocurrency>
+            <cryptocurrency>BTC</cryptocurrency>
+            <cryptocurrency>ETH</cryptocurrency>
+            <cryptocurrency>LTC</cryptocurrency>
+        </exchange>
+        <ratesource prefix="binancejersey" name="Binance Jersey">
+            <param name="fiatcurrency" />
+            <cryptocurrency>BCH</cryptocurrency>
+            <cryptocurrency>BNB</cryptocurrency>
+            <cryptocurrency>BTC</cryptocurrency>
+            <cryptocurrency>ETH</cryptocurrency>
+            <cryptocurrency>LTC</cryptocurrency>
+        </ratesource>
+
     </extension>
     <extension class="com.generalbytes.batm.server.extensions.extra.bitcoincash.BitcoinCashExtension">
         <wallet prefix="bitcoincashd" name="BitcoinABC/BitcoinClassic Cash Core - bitcoind" >

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceExchangeTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceExchangeTest.java
@@ -1,0 +1,32 @@
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.binance;
+
+import com.generalbytes.batm.server.extensions.IExchangeAdvanced;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class BinanceExchangeTest {
+    @Ignore
+    @Test
+    public void test() {
+//        BinanceUsExchange rs = new BinanceUsExchange("USD");
+//        System.out.println(rs.getExchangeRateLast("BTC", "USD"));
+//        System.out.println(rs.getExchangeRateLast("LTC", "USD"));
+//        System.out.println(rs.calculateBuyPrice("BTC", "USD", new BigDecimal("1")));
+//        System.out.println(rs.calculateSellPrice("BTC", "USD", new BigDecimal("1")));
+
+        for (IExchangeAdvanced xch : new IExchangeAdvanced[]{
+            new BinanceUsExchange("", "", "USD"),
+            new BinanceJerseyExchange("", "", "EUR"),
+            new BinanceComExchange("", "", "USD"),
+        }) {
+            System.out.println(xch.getCryptoBalance("LTC"));
+            System.out.println(xch.getFiatBalance("USD"));
+
+            System.out.println(xch.getDepositAddress("LTC"));
+
+//        System.out.println(xch.sellCoins(new BigDecimal("1"), "LTC", "EUR", ""));
+//        System.out.println(xch.purchaseCoins(new BigDecimal("1"), "LTC", "EUR", ""));
+//        System.out.println(xch.sendCoins("", new BigDecimal("0.01"), "LTC", ""));
+        }
+    }
+}

--- a/server_extensions_extra/src/test/resources/logback-test.xml
+++ b/server_extensions_extra/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%-5level %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread - %logger{36}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="com.generalbytes" level="trace"/>
+    <logger name="batm" level="trace"/>
+    <logger name="org.knowm.xchange" level="debug"/>
+    <logger name="si.mazi.rescu" level="debug"/>
+
+</configuration>


### PR DESCRIPTION
Support for Binance.com (no fiat), Binance US (USD) and Binance Jersey (EUR, GBP).
We have another feature requests to use stablecoins as fiat which would be useful for binance.com users.