### PR TITLE
[Bitfinex] fix BCH - do not call remote init

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitfinex/BitfinexExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitfinex/BitfinexExchange.java
@@ -242,16 +242,8 @@ public class BitfinexExchange implements IExchangeAdvanced, IRateSourceAdvanced 
         try {
             DDOSUtils.waitForPossibleCall(getClass());
             String result = accountService.withdrawFunds(Currency.getInstance(getExchangeSpecificSymbol(cryptoCurrency)), amount, destinationAddress);
-            if (result == null) {
-                log.warn("Bitfinex exchange (withdrawFunds) failed with null");
-                return null;
-            }else if ("success".equalsIgnoreCase(result)){
-                log.warn("Bitfinex exchange (withdrawFunds) finished successfully");
-                return "success";
-            }else{
-                log.warn("Bitfinex exchange (withdrawFunds) failed with message: " + result);
-                return null;
-            }
+            log.debug("Bitfinex exchange (withdrawFunds) result: {}", result);
+            return result;
         } catch (IOException e) {
             log.error("Error", e);
             log.error("Bitfinex exchange (withdrawFunds) failed with message: " + e.getMessage());

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitfinex/BitfinexExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitfinex/BitfinexExchange.java
@@ -116,6 +116,7 @@ public class BitfinexExchange implements IExchangeAdvanced, IRateSourceAdvanced 
             ExchangeSpecification bfxSpec = new HofixBitfinexExchange().getDefaultExchangeSpecification();
             bfxSpec.setApiKey(this.apiKey);
             bfxSpec.setSecretKey(this.apiSecret);
+            bfxSpec.setShouldLoadRemoteMetaData(false);
             this.exchange = new HofixBitfinexExchange();
             exchange.applySpecification(bfxSpec);
         }


### PR DESCRIPTION
 BCH pairs  missing in the remote init but present if calling only local init (from a json config file)