### PR TITLE
GB-1464 Fix Bitpanda Pro amount precision and price calculation

### DIFF
--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchangeTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchangeTest.java
@@ -66,13 +66,13 @@ public class BitpandaProExchangeTest {
 
     @Test
     public void shouldSellCoins() {
-        final String orderId = subject.sellCoins(BigDecimal.ONE, BTC.getCode(), EUR.getCode(), "batm-sell-test");
+        final String orderId = subject.sellCoins(new BigDecimal("0.01"), BTC.getCode(), EUR.getCode(), "batm-sell-test");
         assertNotNull(orderId);
     }
 
     @Test
     public void shouldSellCoinsAdvanced() throws InterruptedException {
-        final ITask task = subject.createSellCoinsTask(BigDecimal.ONE, BTC.getCode(), EUR.getCode(), "batm-sell-advanced-test");
+        final ITask task = subject.createSellCoinsTask(new BigDecimal("0.02"), BTC.getCode(), EUR.getCode(), "batm-sell-advanced-test");
         task.onCreate();
         for (int i = 0; i < 10 && !task.isFinished(); i++) {
             Thread.sleep(1000L);
@@ -83,13 +83,13 @@ public class BitpandaProExchangeTest {
 
     @Test
     public void shouldPurchaseCoins() {
-        final String orderId = subject.purchaseCoins(BigDecimal.ONE, BTC.getCode(), EUR.getCode(), "batm-purchase-test");
+        final String orderId = subject.purchaseCoins(new BigDecimal("0.01"), BTC.getCode(), EUR.getCode(), "batm-purchase-test");
         assertNotNull(orderId);
     }
 
     @Test
     public void shouldPurchaseCoinsAdvanced() throws InterruptedException {
-        final ITask task = subject.createPurchaseCoinsTask(BigDecimal.TEN, BTC.getCode(), EUR.getCode(), "batm-purchase-advanced-test");
+        final ITask task = subject.createPurchaseCoinsTask(new BigDecimal("0.02"), BTC.getCode(), EUR.getCode(), "batm-purchase-advanced-test");
         task.onCreate();
         for (int i = 0; i < 10 && !task.isFinished(); i++) {
             Thread.sleep(1000L);


### PR DESCRIPTION
Limit orders were created using the price from `calculateBuyPrice` and
`calculateSellPrice` respectively. But these methods do not yield a
limit order price, but the full price to buy the given amount of
cryptos.

Add `amount_precision` for each market and round crypto amounts to not
exceed the allowed precisions.