### PR TITLE
Add ILCoin to coingecko rate source

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/sources/coingecko/CoinGeckoRateSource.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/sources/coingecko/CoinGeckoRateSource.java
@@ -61,6 +61,7 @@ public class CoinGeckoRateSource implements IRateSource {
         CRYPTOCURRENCIES.put(CryptoCurrency.FTO.getCode(), "futurocoin");
         CRYPTOCURRENCIES.put(CryptoCurrency.GRS.getCode(), "groestlcoin");
         CRYPTOCURRENCIES.put(CryptoCurrency.HATCH.getCode(), "hatch");
+        CRYPTOCURRENCIES.put(CryptoCurrency.ILC.getCode(), "ilcoin");
         CRYPTOCURRENCIES.put(CryptoCurrency.KMD.getCode(), "komodo");
         CRYPTOCURRENCIES.put(CryptoCurrency.LEO.getCode(), "leocoin");
         CRYPTOCURRENCIES.put(CryptoCurrency.LINDA.getCode(), "linda");

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -131,6 +131,7 @@
                 <cryptocurrency>ANT</cryptocurrency>
                 <cryptocurrency>DASH</cryptocurrency>
                 <cryptocurrency>HATCH</cryptocurrency>
+                <cryptocurrency>ILC</cryptocurrency>
                 <cryptocurrency>XMR</cryptocurrency>
                 <cryptocurrency>$PAC</cryptocurrency>
                 <cryptocurrency>POT</cryptocurrency>


### PR DESCRIPTION
This pull request adds missed ILCoin crypto currency to CoinGeckoRateSource