### PR TITLE
Security: fix certificate pinning in HexStringCertTrustManager

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/util/net/HexStringCertTrustManager.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/util/net/HexStringCertTrustManager.java
@@ -53,19 +53,29 @@ public class HexStringCertTrustManager implements X509TrustManager {
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
 
-        boolean match = false;
         try {
-            for (X509Certificate c : chain) {
-                if (c.equals(cert)) {
-                    match = true;
-                }
+            //
+            // A TLS server can send as many certificates as it wants (as part of its certificate
+            // chain), but it's only guaranteed for the first certificate (chain[0]) that it
+            // actually also possesses the matching private key (as otherwise it wouldn't be able
+            // to open the TLS session).
+            //
+            // All other certs (chain[1]...chain[n]) should be considered as UNTRUSTED (a malicious
+            // server can include ANY cert in the chain, even one where it doesn't possess the
+            // private key).
+            //
+            // Certs are public knowledge (basically they are just public keys wth some metadata).
+            // So anybody who can connect to a TLS server can acquire its certificate.
+            //
+            if (chain[0].equals(cert)) {
+                return;
             }
         } catch (Exception e) {
             throw new CertificateException();
         }
 
-        if (!match)
-            throw new CertificateException();
+        // if we come here, certificate is not valid
+        throw new CertificateException();
     }
 
     @Override


### PR DESCRIPTION
## TL;DR:
Certificate pinning in `HexStringCertTrustManager` could easily be circumvented, this PR fixes this.

## Details:
The method argument `chain` in `X509TrustManager.checkClientTrusted(X509Certificate[] chain, String authType)` receives a list of certificates which it received from a TLS server during the TLS handshake in the `Certificate` message directly after the `ServerHello` message. 

This list of certificates contains at least the servers own certificate but may also contain an arbitrary number of addidtional certificates. (This normally might be intermediate certificates provided by the server to enable the TLS client to build a valid trust chain from the server's own certificate until a known trusted root-certificate.)

The key points are: 
- certificates are public knowledge (anybody can retrieve a server's TLS certificate by just connecting to it)
- a TLS server can include any certificate in its `Certificate` message
- only the first certificate (the server's own, `chain[0]`) should be considered as trusted (i.e. trusting that the server possesses the matching private key) as otherwise the rest of the TLS session setup would fail anyway.

In the current implementation a man-in-the-middle could just setup a TLS server using ANY self-created TLS cert and just needs to add the certificate of the actual real server in its `Certificate` message (which it can easily obtain from the real server). --> Thus the current implementation does not provide certificate pinning.

See for reference:

![TLS-handshake](https://user-images.githubusercontent.com/285900/98265534-7a6ee280-1f89-11eb-852a-c026e5db4d16.png)
