### PR TITLE
[BitpandaPro] Support BTC/GBP

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
@@ -76,10 +76,12 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
         return new BitpandaProExchange(LIVE_URL, apikey, preferredFiatCurrency);
     }
 
-    // all CRYPTO_FIAT combinations are supported
+    // all CRYPTO_FIAT combinations are supported for EUR and CHF pairs
+    // GBP supports only BTC
     private static final ImmutableSet<String> FIAT_CURRENCIES = ImmutableSet.of(
         FiatCurrency.EUR.getCode(),
-        FiatCurrency.CHF.getCode()
+        FiatCurrency.CHF.getCode(),
+        FiatCurrency.GBP.getCode()
     );
     private static final ImmutableSet<String> CRYPTO_CURRENCIES = ImmutableSet.of(
         CryptoCurrency.BTC.getCode(),
@@ -576,7 +578,11 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
     private String asInstrument(String base, String quote) {
         assertValidCrypto(base);
         assertValidFiat(quote);
-        // all crypto/fiat pairs are supported
+        // GBP only supports BTC
+        if (FiatCurrency.GBP.getCode().equals(quote) && !CryptoCurrency.BTC.getCode().equals(base)) {
+            final String msg = format("%s_%s is not a supported pair", base, quote);
+            throw new IllegalArgumentException(msg);
+        } // EUR and CHF support all crypto combinations
         return base + "_" + quote;
     }
 

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchangeTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchangeTest.java
@@ -1,13 +1,18 @@
 package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bitpandapro;
 
 import static com.generalbytes.batm.common.currencies.CryptoCurrency.BTC;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.ETH;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.XRP;
+import static com.generalbytes.batm.common.currencies.FiatCurrency.CHF;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.EUR;
+import static com.generalbytes.batm.common.currencies.FiatCurrency.GBP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.net.URI;
+import java.util.stream.Stream;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -39,17 +44,21 @@ public class BitpandaProExchangeTest {
     }
 
     @Test
-    public void shouldFetchEuroBalance() {
-        final BigDecimal balance = subject.getFiatBalance(EUR.getCode());
-        assertNotNull(balance);
-        assertTrue("negative balance", balance.compareTo(BigDecimal.ZERO) >= 0);
+    public void shouldFetchFiatBalances() {
+        Stream.of(EUR, CHF, GBP).forEach(currency -> {
+            final BigDecimal balance = subject.getFiatBalance(EUR.getCode());
+            assertNotNull("getFiatBalance(" + currency + ")", balance);
+            assertTrue("negative balance", balance.compareTo(BigDecimal.ZERO) >= 0);
+        });
     }
 
     @Test
-    public void shouldFetchBitcoinBalance() {
-        final BigDecimal balance = subject.getCryptoBalance(BTC.getCode());
-        assertNotNull(balance);
-        assertTrue("negative balance", balance.compareTo(BigDecimal.ZERO) >= 0);
+    public void shouldFetchCryptoBalances() {
+        Stream.of(BTC, ETH, XRP).forEach(currency -> {
+            final BigDecimal balance = subject.getCryptoBalance(BTC.getCode());
+            assertNotNull("getCryptoBalance(" + currency + ")", balance);
+            assertTrue("negative balance", balance.compareTo(BigDecimal.ZERO) >= 0);
+        });
     }
 
     @Test

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProRateSourceTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProRateSourceTest.java
@@ -1,9 +1,12 @@
 package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bitpandapro;
 
 import static com.generalbytes.batm.common.currencies.CryptoCurrency.BTC;
+import static com.generalbytes.batm.common.currencies.FiatCurrency.CHF;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.EUR;
+import static com.generalbytes.batm.common.currencies.FiatCurrency.GBP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
@@ -34,6 +37,20 @@ public class BitpandaProRateSourceTest {
     @Test
     public void shouldYieldConfiguredPreferredFiatCurrency() {
         assertEquals("EUR", subject.getPreferredFiatCurrency());
+    }
+
+    @Test
+    public void shouldFailOnInvalidInstrument() {
+        // bogus crypto
+        assertNull(subject.getExchangeRateLast("GAGA", "EUR"));
+        // bogus fiat
+        assertNull(subject.getExchangeRateLast("BTC", "GAGA"));
+        // fiat <> fiat
+        assertNull(subject.getExchangeRateLast("EUR", "CHF"));
+        // crypto <> crypto
+        assertNull(subject.getExchangeRateLast("BTC", "ETH"));
+        // GBP only supports BTC
+        assertNull(subject.getExchangeRateLast("ETH", "GBP"));
     }
 
     @Test
@@ -71,5 +88,16 @@ public class BitpandaProRateSourceTest {
         assertTrue("calculated non-positive sell price", sell.compareTo(BigDecimal.ZERO) > 0);
 
         assertTrue("buy price is smaller than sell", buy.compareTo(sell) >= 0);
+    }
+
+    @Test
+    public void shouldSupportAllConfiguredPairs() {
+        assertNotNull("BTC/EUR", subject.getExchangeRateLast(BTC.getCode(), EUR.getCode()));
+        assertNotNull("ETH/EUR", subject.getExchangeRateLast(BTC.getCode(), EUR.getCode()));
+        assertNotNull("XRP/EUR", subject.getExchangeRateLast(BTC.getCode(), EUR.getCode()));
+        assertNotNull("BTC/CHF", subject.getExchangeRateLast(BTC.getCode(), CHF.getCode()));
+        assertNotNull("ETH/CHF", subject.getExchangeRateLast(BTC.getCode(), CHF.getCode()));
+        assertNotNull("XRP/CHF", subject.getExchangeRateLast(BTC.getCode(), CHF.getCode()));
+        assertNotNull("BTC/GBP", subject.getExchangeRateLast(BTC.getCode(), GBP.getCode()));
     }
 }


### PR DESCRIPTION
Market was opened today (2020-11-12) and trading will start on 2020-11-19 .