### PR TITLE
BPUB-1365 Allows to set the feeRate parameter for BitGo wallets

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -263,6 +263,7 @@ public class BitcoinExtension extends AbstractExtension {
                 // bitgo:http://localhost:token:wallet_address:wallet_passphrase
                 // bitgo:localhost:token:wallet_address:wallet_passphrase
                 // bitgo:localhost:80:token:wallet_address:wallet_passphrase
+                // bitgo:localhost:80:token:wallet_address:wallet_passphrase:fee_rate
 
                 String first = st.nextToken();
                 String scheme;
@@ -292,10 +293,15 @@ public class BitcoinExtension extends AbstractExtension {
                 host = tunnelAddress.getHostString();
                 port = tunnelAddress.getPort();
 
+                String feeRate = "";
+                if (st.hasMoreTokens()) {
+                  feeRate = st.nextToken();
+                }
+
                 if ("bitgonoforward".equalsIgnoreCase(walletType)) {
                     return new BitgoWalletWithUniqueAddresses(scheme, host, port, token, walletAddress, walletPassphrase);
                 }
-                return new BitgoWallet(scheme, host, port, token, walletAddress, walletPassphrase);
+                return new BitgoWallet(scheme, host, port, token, walletAddress, walletPassphrase, feeRate);
 
             } else if ("coinbasewallet2".equalsIgnoreCase(walletType)
                 || "coinbasewallet2noforward".equalsIgnoreCase(walletType)) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -294,8 +294,12 @@ public class BitcoinExtension extends AbstractExtension {
                 port = tunnelAddress.getPort();
 
                 String feeRate = "";
+                String fee = "";
                 if (st.hasMoreTokens()) {
-                  feeRate = st.nextToken();
+                  fee = st.nextToken();
+                  if (Integer.parseInt(fee) >= 1) {
+                    feeRate = fee;
+                  }
                 }
 
                 if ("bitgonoforward".equalsIgnoreCase(walletType)) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
@@ -53,11 +53,17 @@ public class BitgoWallet implements IWallet, ICanSendMany {
     protected String walletId;
     protected String walletPassphrase;
     protected String url;
+    protected String feeRate;
     protected static final Integer readTimeout = 90 * 1000; //90 seconds
 
     public BitgoWallet(String scheme, String host, int port, String token, String walletId, String walletPassphrase) {
+      this(scheme, host, port, token, walletId, walletPassphrase, "");
+    }
+
+    public BitgoWallet(String scheme, String host, int port, String token, String walletId, String walletPassphrase, String feeRate) {
         this.walletId = walletId;
         this.walletPassphrase = walletPassphrase;
+        this.feeRate = feeRate;
         this.url = new HttpUrl.Builder().scheme(scheme).host(host).port(port).build().toString();
 
         ClientConfig config = new ClientConfig();
@@ -105,7 +111,7 @@ public class BitgoWallet implements IWallet, ICanSendMany {
 
     @Override
     public String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
-        final BitGoCoinRequest request = new BitGoCoinRequest(destinationAddress, toSatoshis(amount, cryptoCurrency), walletPassphrase);
+        final BitGoCoinRequest request = new BitGoCoinRequest(destinationAddress, toSatoshis(amount, cryptoCurrency), walletPassphrase, this.feeRate);
         try {
             return getResultTxId(api.sendCoins(cryptoCurrency.toLowerCase(), this.walletId, request));
         } catch (HttpStatusIOException hse) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletWithUniqueAddresses.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletWithUniqueAddresses.java
@@ -28,8 +28,12 @@ import si.mazi.rescu.HttpStatusIOException;
 public class BitgoWalletWithUniqueAddresses extends BitgoWallet implements IGeneratesNewDepositCryptoAddress {
     private static final Logger log = LoggerFactory.getLogger(BitgoWalletWithUniqueAddresses.class);
 
-    public BitgoWalletWithUniqueAddresses(String scheme, String host, int port, String token, String walletId, String walletPassphrase) {
-        super(scheme, host, port, token, walletId, walletPassphrase);
+    public BitgoWalletWithUniqueAddresses(String scheme, String host, int port, String token, String walletId, String walletPassphrase){
+      super(scheme, host, port, token, walletId, walletPassphrase, "");
+    }
+
+    public BitgoWalletWithUniqueAddresses(String scheme, String host, int port, String token, String walletId, String walletPassphrase, String feeRate) {
+        super(scheme, host, port, token, walletId, walletPassphrase, feeRate);
     }
 
     @Override

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoCoinRequest.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoCoinRequest.java
@@ -21,11 +21,13 @@ public class BitGoCoinRequest {
     private String address;
     private Integer amount;
     private String walletPassphrase;
+    private String feeRate;
 
-    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase) {
+    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase, String feeRate) {
         this.address = address;
         this.amount = amount;
         this.walletPassphrase = walletPassphrase;
+        this.feeRate = feeRate;
     }
 
     public String getAddress() {
@@ -50,5 +52,13 @@ public class BitGoCoinRequest {
 
     public void setWalletPassphrase(String walletPassphrase) {
         this.walletPassphrase = walletPassphrase;
+    }
+
+    public String getFeeRate(){
+      return feeRate;
+    }
+
+    public void setFee(String feeRate){
+      this.feeRate = feeRate;
     }
 }

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -36,6 +36,7 @@
                 <param name="token" />
                 <param name="wallet_id" />
                 <param name="wallet_passphrase" />
+                <param name="fee_rate" />
                 <cryptocurrency buyonly="true">BCH</cryptocurrency>
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>
@@ -50,6 +51,7 @@
                 <param name="token" />
                 <param name="wallet_id" />
                 <param name="wallet_passphrase" />
+                <param name="fee_rate" />
                 <cryptocurrency buyonly="true">BCH</cryptocurrency>
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -41,7 +41,7 @@
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>
                 <cryptocurrency>ETH</cryptocurrency><!--BitGo’s Ethereum wallets are only available to BitGo Enterprise customers-->
-                <help>Host should start with http:// or https://</help>
+                <help>Host should start with http:// or https://. Fee rate is the value in satoshis per vbyte, if set, it must be at least 1.</help>
             </wallet>
             <wallet prefix="bitgonoforward" name="BitGo Wallet (no forward)">
                 <sendtomany supported="true"/>
@@ -56,7 +56,7 @@
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>
                 <cryptocurrency>ETH</cryptocurrency><!--BitGo’s Ethereum wallets are only available to BitGo Enterprise customers-->
-                <help>This variant of the wallet generates new addresses for each transaction and does not forward payments from temporary address. Host should start with http:// or https://</help>
+                <help>This variant of the wallet generates new addresses for each transaction and does not forward payments from temporary address. Host should start with http:// or https://. Fee rate is the value in satoshis per vbyte, if set, it must be at least 1.</help>
             </wallet>
             <wallet prefix="cryptx" name="CryptX Wallet System">
                 <sendtomany supported="false"/>

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoAPITest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoAPITest.java
@@ -250,7 +250,7 @@ public class BitgoAPITest {
             final Integer amount = 10000;
             final String walletPassphrase = "JSZSuGNlHfgqPHjrp0eO";
 
-            final BitGoCoinRequest request = new BitGoCoinRequest(address, amount, walletPassphrase);
+            final BitGoCoinRequest request = new BitGoCoinRequest(address, amount, walletPassphrase, "");
             String accessToken = "Bearer v2x8d5e9e46379dc328b2039a400a12b04ea986689b38107fd84cd339bc89e3fb21";
             String contentType = "application/json";
             Map<String, Object> result = localapi.sendCoins(coin, id, request);

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletTest.java
@@ -25,6 +25,8 @@ public class BitgoWalletTest {
     private static IBitgoAPI api;
 
     private static BitgoWallet wallet;
+    
+    private static BitgoWallet walletFee;
 
     private static void setLoggerLevel(String name, String level) {
         try {
@@ -55,8 +57,10 @@ public class BitgoWalletTest {
         String token = "v2x8d5e9e46379dc328b2039a400a12b04ea986689b38107fd84cd339bc89e3fb21";
         String walletId = "5b20e3a9266bbe80095757489d84a6bb";
         String walletPassphrase = "JSZSuGNlHfgqPHjrp0eO";
+        String feeRate = "10";
 
         wallet = new BitgoWallet(scheme, host, port, token, walletId, walletPassphrase);
+        walletFee = new BitgoWallet(scheme, host, port, token, walletId, walletPassphrase, feeRate);
     }
 
     @Test
@@ -119,5 +123,18 @@ public class BitgoWalletTest {
             new ICanSendMany.Transfer("2N5q4MwNSUxbAtaidhRgkiDrbwVR4yCZDhi", new BigDecimal("0.002"))
         ), coin, "test send to self");
         log.info("send coins status = {}", result);
+    }
+    
+    @Test
+    @Ignore("Local instance of bitgo-express is required to run")
+    public void sendCoinsFeeTest() {
+      String destinationAddress = "2N5q4MwNSUxbAtaidhRgkiDrbwVR4yCZDhi";
+      String coin = CryptoCurrency.TBTC.getCode();
+      Integer amountInt = 10000;
+      BigDecimal amount = BigDecimal.valueOf(amountInt).divide(Converters.TBTC);
+      String description = null;
+
+      String result = walletFee.sendCoins(destinationAddress, amount, coin, description);
+      log.info("send coins status = {}", result);
     }
 }


### PR DESCRIPTION
This change extends the BitGoWallet configuration to allow the setting of a fixed `feeRate` parameter for all the outgoing Bitcoin transactions. The parameter has to be an integer greater or equal than one.

Note: When not set, the default fee rate is automatically calculated by the proprietary BitGo algorithm, which aims to have the transaction to be included in the next block. This may not work for operators since it could mean paying high value fees.