### PR TITLE
[BitpandaPro] Support BTC/TRY and ETH/TRY

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
@@ -76,12 +76,14 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
         return new BitpandaProExchange(LIVE_URL, apikey, preferredFiatCurrency);
     }
 
-    // all CRYPTO_FIAT combinations are supported for EUR and CHF pairs
+    // EUR and CHF support all CRYPTO_FIAT combinations
     // GBP supports only BTC
+    // TRY supports BTC and ETH
     private static final ImmutableSet<String> FIAT_CURRENCIES = ImmutableSet.of(
         FiatCurrency.EUR.getCode(),
         FiatCurrency.CHF.getCode(),
-        FiatCurrency.GBP.getCode()
+        FiatCurrency.GBP.getCode(),
+        FiatCurrency.TRY.getCode()
     );
     private static final ImmutableSet<String> CRYPTO_CURRENCIES = ImmutableSet.of(
         CryptoCurrency.BTC.getCode(),
@@ -97,6 +99,8 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
         .put("ETH_CHF", 4)
         .put("XRP_CHF", 0)
         .put("BTC_GBP", 5)
+        .put("BTC_TRY", 7)
+        .put("ETH_TRY", 6)
         .build()
     ;
 
@@ -579,12 +583,16 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
     private String asInstrument(String base, String quote) {
         assertValidCrypto(base);
         assertValidFiat(quote);
-        // GBP only supports BTC
-        if (FiatCurrency.GBP.getCode().equals(quote) && !CryptoCurrency.BTC.getCode().equals(base)) {
-            final String msg = format("%s_%s is not a supported pair", base, quote);
+
+        final String instrument = base + "_" + quote;
+
+        // verify that the pair is supported
+        if (!INSTRUMENT_AMOUNT_PRECISION.containsKey(instrument)) {
+            final String msg = format("%s is not a supported pair", instrument);
             throw new IllegalArgumentException(msg);
-        } // EUR and CHF support all crypto combinations
-        return base + "_" + quote;
+        }
+
+        return instrument;
     }
 
     private void assertValidCrypto(String code) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
@@ -96,6 +96,7 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
         .put("BTC_CHF", 5)
         .put("ETH_CHF", 4)
         .put("XRP_CHF", 0)
+        .put("BTC_GBP", 5)
         .build()
     ;
 

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProRateSourceTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProRateSourceTest.java
@@ -1,16 +1,18 @@
 package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bitpandapro;
 
 import static com.generalbytes.batm.common.currencies.CryptoCurrency.BTC;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.ETH;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.XRP;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.CHF;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.EUR;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.GBP;
+import static com.generalbytes.batm.common.currencies.FiatCurrency.TRY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
-import java.net.URI;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -19,10 +21,8 @@ import com.generalbytes.batm.server.extensions.IRateSourceAdvanced;
 
 @Ignore // requires online resources - for manual run only
 public class BitpandaProRateSourceTest {
-    /** exchange sandbox */
-    private static final URI API = URI.create("https://api.exchange.waskurzes.com");
 
-    private final IRateSourceAdvanced subject = new BitpandaProExchange(API, null, EUR.getCode());
+    private final IRateSourceAdvanced subject = BitpandaProExchange.asRateSource(EUR.getCode());
 
     @Test
     public void shouldFetchCryptoCurrencies() {
@@ -51,6 +51,8 @@ public class BitpandaProRateSourceTest {
         assertNull(subject.getExchangeRateLast("BTC", "ETH"));
         // GBP only supports BTC
         assertNull(subject.getExchangeRateLast("ETH", "GBP"));
+        // TRY only supports BTC and ETH
+        assertNull(subject.getExchangeRateLast("XRP", "TRY"));
     }
 
     @Test
@@ -93,11 +95,13 @@ public class BitpandaProRateSourceTest {
     @Test
     public void shouldSupportAllConfiguredPairs() {
         assertNotNull("BTC/EUR", subject.getExchangeRateLast(BTC.getCode(), EUR.getCode()));
-        assertNotNull("ETH/EUR", subject.getExchangeRateLast(BTC.getCode(), EUR.getCode()));
-        assertNotNull("XRP/EUR", subject.getExchangeRateLast(BTC.getCode(), EUR.getCode()));
+        assertNotNull("ETH/EUR", subject.getExchangeRateLast(ETH.getCode(), EUR.getCode()));
+        assertNotNull("XRP/EUR", subject.getExchangeRateLast(XRP.getCode(), EUR.getCode()));
         assertNotNull("BTC/CHF", subject.getExchangeRateLast(BTC.getCode(), CHF.getCode()));
-        assertNotNull("ETH/CHF", subject.getExchangeRateLast(BTC.getCode(), CHF.getCode()));
-        assertNotNull("XRP/CHF", subject.getExchangeRateLast(BTC.getCode(), CHF.getCode()));
+        assertNotNull("ETH/CHF", subject.getExchangeRateLast(ETH.getCode(), CHF.getCode()));
+        assertNotNull("XRP/CHF", subject.getExchangeRateLast(XRP.getCode(), CHF.getCode()));
         assertNotNull("BTC/GBP", subject.getExchangeRateLast(BTC.getCode(), GBP.getCode()));
+        assertNotNull("BTC/TRY", subject.getExchangeRateLast(BTC.getCode(), TRY.getCode()));
+        assertNotNull("ETH/TRY", subject.getExchangeRateLast(ETH.getCode(), TRY.getCode()));
     }
 }


### PR DESCRIPTION
Bitpanda Pro launched TRY markets:

https://blog.bitpanda.com/bitpanda-pro-announces-turkish-trading-competition-and-turkish-lira-pairs/

This PR adds support for the `BTC` and `ETH` pairs.