### PR TITLE
BPUB-1365 BitGo adds numblocks parameter

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -257,12 +257,14 @@ public class BitcoinExtension extends AbstractExtension {
                 String proxyUrl = st.nextToken("\n").replaceFirst(":", "");
                 return new BitcoreWallet(apiKey, proxyUrl);
             } else if ("bitgo".equalsIgnoreCase(walletType) || "bitgonoforward".equalsIgnoreCase(walletType)) {
-                // bitgo:host:port:token:wallet_address:wallet_passphrase
-                // but host is optionally including the "http://" and port is optional
+                // bitgo:host:port:token:wallet_address:wallet_passphrase:num_blocks
+                // but host is optionally including the "http://" and port is optional,
+                // num_blocks is an optional integer greater than 2 and it's used to calculate mining fee.
                 // bitgo:http://localhost:80:token:wallet_address:wallet_passphrase
                 // bitgo:http://localhost:token:wallet_address:wallet_passphrase
                 // bitgo:localhost:token:wallet_address:wallet_passphrase
                 // bitgo:localhost:80:token:wallet_address:wallet_passphrase
+                // bitgo:localhost:80:token:wallet_address:wallet_passphrase:num_blocks
 
                 String first = st.nextToken();
                 String scheme;
@@ -292,10 +294,22 @@ public class BitcoinExtension extends AbstractExtension {
                 host = tunnelAddress.getHostString();
                 port = tunnelAddress.getPort();
 
-                if ("bitgonoforward".equalsIgnoreCase(walletType)) {
-                    return new BitgoWalletWithUniqueAddresses(scheme, host, port, token, walletAddress, walletPassphrase);
+                String blocks;
+                int num;
+                Integer numBlocks = 2;
+                if(st.hasMoreTokens()){
+                  blocks = st.nextToken();
+                  num = Integer.parseInt(blocks);
+                  if(num > 2) {
+                    numBlocks = num;
+                  }
                 }
-                return new BitgoWallet(scheme, host, port, token, walletAddress, walletPassphrase);
+
+                if ("bitgonoforward".equalsIgnoreCase(walletType)) {
+                  return new BitgoWalletWithUniqueAddresses(scheme, host, port, token, walletType, walletPassphrase, numBlocks);
+                }
+
+                return new BitgoWallet(scheme, host, port, token, walletAddress, walletPassphrase, numBlocks);
 
             } else if ("coinbasewallet2".equalsIgnoreCase(walletType)
                 || "coinbasewallet2noforward".equalsIgnoreCase(walletType)) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -306,7 +306,7 @@ public class BitcoinExtension extends AbstractExtension {
                 }
 
                 if ("bitgonoforward".equalsIgnoreCase(walletType)) {
-                  return new BitgoWalletWithUniqueAddresses(scheme, host, port, token, walletType, walletPassphrase, numBlocks);
+                  return new BitgoWalletWithUniqueAddresses(scheme, host, port, token, walletAddress, walletPassphrase, numBlocks);
                 }
 
                 return new BitgoWallet(scheme, host, port, token, walletAddress, walletPassphrase, numBlocks);

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
@@ -54,11 +54,17 @@ public class BitgoWallet implements IWallet, ICanSendMany {
     protected String walletPassphrase;
     protected String url;
     protected static final Integer readTimeout = 90 * 1000; //90 seconds
+    protected Integer numBlocks;
 
     public BitgoWallet(String scheme, String host, int port, String token, String walletId, String walletPassphrase) {
+      this(scheme, host, port, token, walletId, walletPassphrase, 2);
+    }
+
+    public BitgoWallet(String scheme, String host, int port, String token, String walletId, String walletPassphrase, Integer numBlocks) {
         this.walletId = walletId;
         this.walletPassphrase = walletPassphrase;
         this.url = new HttpUrl.Builder().scheme(scheme).host(host).port(port).build().toString();
+        this.numBlocks = numBlocks;
 
         ClientConfig config = new ClientConfig();
         config.setHttpReadTimeout(readTimeout);
@@ -90,7 +96,7 @@ public class BitgoWallet implements IWallet, ICanSendMany {
         List<BitGoRecipient> recipients = transfers.stream()
             .map(transfer -> new BitGoRecipient(transfer.getDestinationAddress(), toSatoshis(transfer.getAmount(), cryptoCurrency)))
             .collect(Collectors.toList());
-        final BitGoSendManyRequest request = new BitGoSendManyRequest(recipients, walletPassphrase);
+        final BitGoSendManyRequest request = new BitGoSendManyRequest(recipients, walletPassphrase, this.numBlocks);
         try {
             return getResultTxId(api.sendMany(cryptoCurrency.toLowerCase(), this.walletId, request));
         } catch (HttpStatusIOException hse) {
@@ -105,7 +111,7 @@ public class BitgoWallet implements IWallet, ICanSendMany {
 
     @Override
     public String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
-        final BitGoCoinRequest request = new BitGoCoinRequest(destinationAddress, toSatoshis(amount, cryptoCurrency), walletPassphrase);
+        final BitGoCoinRequest request = new BitGoCoinRequest(destinationAddress, toSatoshis(amount, cryptoCurrency), walletPassphrase, this.numBlocks);
         try {
             return getResultTxId(api.sendCoins(cryptoCurrency.toLowerCase(), this.walletId, request));
         } catch (HttpStatusIOException hse) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletWithUniqueAddresses.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletWithUniqueAddresses.java
@@ -28,8 +28,8 @@ import si.mazi.rescu.HttpStatusIOException;
 public class BitgoWalletWithUniqueAddresses extends BitgoWallet implements IGeneratesNewDepositCryptoAddress {
     private static final Logger log = LoggerFactory.getLogger(BitgoWalletWithUniqueAddresses.class);
 
-    public BitgoWalletWithUniqueAddresses(String scheme, String host, int port, String token, String walletId, String walletPassphrase) {
-        super(scheme, host, port, token, walletId, walletPassphrase);
+    public BitgoWalletWithUniqueAddresses(String scheme, String host, int port, String token, String walletId, String walletPassphrase, Integer numBlocks) {
+        super(scheme, host, port, token, walletId, walletPassphrase, numBlocks);
     }
 
     @Override

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoCoinRequest.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoCoinRequest.java
@@ -21,11 +21,18 @@ public class BitGoCoinRequest {
     private String address;
     private Integer amount;
     private String walletPassphrase;
+    private Integer numBlocks;
+
 
     public BitGoCoinRequest(String address, Integer amount, String walletPassphrase) {
+      this(address, amount, walletPassphrase, 2);
+    }
+
+    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase, Integer numBlocks) {
         this.address = address;
         this.amount = amount;
         this.walletPassphrase = walletPassphrase;
+        this.numBlocks = numBlocks;
     }
 
     public String getAddress() {
@@ -50,5 +57,13 @@ public class BitGoCoinRequest {
 
     public void setWalletPassphrase(String walletPassphrase) {
         this.walletPassphrase = walletPassphrase;
+    }
+
+    public void setNumBlocks(Integer numBlocks){
+      this.numBlocks = numBlocks;
+    }
+
+    public Integer getNumBlocks() {
+      return numBlocks;
     }
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoSendManyRequest.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoSendManyRequest.java
@@ -22,10 +22,16 @@ import java.util.List;
 public class BitGoSendManyRequest {
     public List<BitGoRecipient> recipients;
     public String walletPassphrase;
+    public Integer numBlocks;
 
-    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase) {
+    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase){
+      this(recipients, walletPassphrase, 2);
+    }
+
+    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase, Integer numBlocks) {
         this.recipients = recipients;
         this.walletPassphrase = walletPassphrase;
+        this.numBlocks = numBlocks;
     }
 
     public static class BitGoRecipient {

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -36,11 +36,12 @@
                 <param name="token" />
                 <param name="wallet_id" />
                 <param name="wallet_passphrase" />
+                <param name="num_blocks" />
                 <cryptocurrency buyonly="true">BCH</cryptocurrency>
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>
                 <cryptocurrency>ETH</cryptocurrency><!--BitGo’s Ethereum wallets are only available to BitGo Enterprise customers-->
-                <help>Host should start with http:// or https://</help>
+                <help>Host should start with http:// or https://. num_blocks is an integer greater than 2.</help>
             </wallet>
             <wallet prefix="bitgonoforward" name="BitGo Wallet (no forward)">
                 <sendtomany supported="true"/>
@@ -50,11 +51,12 @@
                 <param name="token" />
                 <param name="wallet_id" />
                 <param name="wallet_passphrase" />
+                <param name="num_blocks" />
                 <cryptocurrency buyonly="true">BCH</cryptocurrency>
                 <cryptocurrency>BTC</cryptocurrency>
                 <cryptocurrency>LTC</cryptocurrency>
                 <cryptocurrency>ETH</cryptocurrency><!--BitGo’s Ethereum wallets are only available to BitGo Enterprise customers-->
-                <help>This variant of the wallet generates new addresses for each transaction and does not forward payments from temporary address. Host should start with http:// or https://</help>
+                <help>This variant of the wallet generates new addresses for each transaction and does not forward payments from temporary address. Host should start with http:// or https://. num_blocks is an integer greater than 2.</help>
             </wallet>
             <wallet prefix="cryptx" name="CryptX Wallet System">
                 <sendtomany supported="false"/>

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWalletTest.java
@@ -26,6 +26,8 @@ public class BitgoWalletTest {
 
     private static BitgoWallet wallet;
 
+    private static BitgoWallet walletParams;
+
     private static void setLoggerLevel(String name, String level) {
         try {
             LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
@@ -55,8 +57,10 @@ public class BitgoWalletTest {
         String token = "v2x8d5e9e46379dc328b2039a400a12b04ea986689b38107fd84cd339bc89e3fb21";
         String walletId = "5b20e3a9266bbe80095757489d84a6bb";
         String walletPassphrase = "JSZSuGNlHfgqPHjrp0eO";
+        int numBlocks = 10;
 
         wallet = new BitgoWallet(scheme, host, port, token, walletId, walletPassphrase);
+        walletParams = new BitgoWallet(scheme, host, port, token, walletId, walletPassphrase, numBlocks);
     }
 
     @Test
@@ -119,5 +123,18 @@ public class BitgoWalletTest {
             new ICanSendMany.Transfer("2N5q4MwNSUxbAtaidhRgkiDrbwVR4yCZDhi", new BigDecimal("0.002"))
         ), coin, "test send to self");
         log.info("send coins status = {}", result);
+    }
+
+    @Test
+    @Ignore("Local instance of bitgo-express is required to run")
+    public void sendCoinsNumBlocksTest() {
+        String destinationAddress = "2N5q4MwNSUxbAtaidhRgkiDrbwVR4yCZDhi";
+        String coin = CryptoCurrency.TBTC.getCode();
+        Integer amountInt = 10000;
+        BigDecimal amount = BigDecimal.valueOf(amountInt).divide(Converters.TBTC);
+        String description = "CAS: uses the numBlocks API parameter";
+
+        String result = walletParams.sendCoins(destinationAddress, amount, coin, description);
+        log.info("send coins with numBlocks parameter status = {}", result);
     }
 }


### PR DESCRIPTION
Adds the ability to use the `numBlocks` API parameter, that is used to calculate mining fees, as an optional parameter to allow operators to manage their fee expenses when the network is congested.

By default BitGo uses a 2-block target to calculate the transaction's mining fee, which may result in expensive fees for some transactions. Using a higher block target (i.e. 20) would result in cheaper fees, but also longer confirmation times. 