### PR TITLE
BPUB-1455 binance withdraw fee

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/XChangeExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/XChangeExchange.java
@@ -204,7 +204,7 @@ public abstract class XChangeExchange implements IExchangeAdvanced, IRateSourceA
         return accountInfo.getWallet(translateCryptoCurrencySymbolToExchangeSpecificSymbol(currency));
     }
 
-    public final String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
+    public String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
         if (!isCryptoCurrencySupported(cryptoCurrency)){
             return null;
         }
@@ -868,5 +868,10 @@ public abstract class XChangeExchange implements IExchangeAdvanced, IRateSourceA
 
     protected String translateCryptoCurrencySymbolToExchangeSpecificSymbol(String from) {
         return from;
+    }
+
+    protected BigDecimal getWithdrawalFee(String cryptoCurrency) {
+        Currency exchangeCryptoCurrency = Currency.getInstance(translateCryptoCurrencySymbolToExchangeSpecificSymbol(cryptoCurrency));
+        return exchange.getExchangeMetaData().getCurrencies().get(exchangeCryptoCurrency).getWithdrawalFee();
     }
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceExchange.java
@@ -100,6 +100,7 @@ public abstract class BinanceExchange extends XChangeExchange {
     private static ExchangeSpecification getDefaultSpecification(String sslUri) {
         ExchangeSpecification spec = new org.knowm.xchange.binance.BinanceExchange().getDefaultExchangeSpecification();
         spec.setSslUri(sslUri);
+        spec.setShouldLoadRemoteMetaData(true); // true is default, but make sure it loads current withdraw fees
         return spec;
     }
 
@@ -139,4 +140,14 @@ public abstract class BinanceExchange extends XChangeExchange {
     protected BigDecimal getAmountRoundedToMinStep(BigDecimal cryptoAmount, BigDecimal minStep) {
         return cryptoAmount.divideToIntegralValue(minStep).multiply(minStep);
     }
+
+    @Override
+    public String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
+        BigDecimal withdrawalFee = getWithdrawalFee(cryptoCurrency);
+        BigDecimal withdrawalAmount = amount.add(withdrawalFee);
+        log.info("Withdrawing {} + {} withdrawal fee = {} {}", amount, withdrawalFee, withdrawalAmount, cryptoCurrency);
+
+        return super.sendCoins(destinationAddress, withdrawalAmount, cryptoCurrency, description);
+    }
+
 }


### PR DESCRIPTION
The buyer's wallet received the amount we specify in the api call subtracted by a withdraw fee.
After this change we will ask to withdraw (send) the "amount" + withdraw fee to get just the "amount" to the destination address.