### PR TITLE
BATM-1844 onfido documentation  + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ How to run Tester
 verification-site
 =================
 It is standalone component that serves static verification website and little server that communicates with CAS.
-Before building and running, configure correctly your settings for HTTPS certificate (e.g. letsencrypt) in `application.properties`.
+Its build around Onfido web SDK. If you need make any modifications to appearance or verification behavior please refer to [this](https://github.com/onfido/onfido-sdk-ui) documentation first.
 
 It can be build with:
 ```bash
@@ -104,3 +104,35 @@ this produces `verification-site-<version>.jar` into `build/libs` directory, and
 ```bash
 java -jar verification_site-<ver>.jar
 ```
+
+By default, verification-site runs on port 8443. You should change it and most importantly configure HTTPS. Here is how to do it with [letsencrypt](https://letsencrypt.org/):
+1. download letsenrypt [certbot](https://github.com/certbot/certbot)
+    ```bash
+    git clone https://github.com/certbot/certbot
+    ```
+
+2. generate certificate for your domain with letsenrypt
+    ```bash
+    ./certbot-auto certonly -a standalone -d example.com -d www.example.com
+    ```
+
+3. convert it to PKCS12 format for Spring Boot
+    ```bash
+    cd /etc/letsencrypt/live/example.com
+    openssl pkcs12 -export -in fullchain.pem -inkey privkey.pem -out keystore.p12 -name tomcat -CAfile chain.pem -caname root
+    ```
+
+4. configure your application
+    - edit [application.properties](verification_site/src/main/resources/application.properties) before building application as follows:
+        ```bash
+        server.port=443
+        security.require-ssl=true
+        server.ssl.key-store=/etc/letsencrypt/live/example.com/keystore.p12
+        server.ssl.key-store-password=<your-password>
+        server.ssl.keyStoreType=PKCS12
+        server.ssl.keyAlias=tomcat
+        ```
+    - or you can pass these parameters in run command as follows:
+        ```bash
+        java -jar verification_site-<ver>.jar --server.port=443 --security.require-ssl=true --server.ssl.key-store=/etc/letsencrypt/live/example.com/keystore.p12 --server.ssl.key-store-password=<your-password> --server.ssl.keyStoreType=PKCS12 --server.ssl.keyAlias=tomcat
+        ```

--- a/verification_site/README.md
+++ b/verification_site/README.md
@@ -1,3 +1,0 @@
-development
-===========
-use `local` profile for locally run verification_site

--- a/verification_site/src/main/java/com/generalbytes/verification/service/ApplicantService.java
+++ b/verification_site/src/main/java/com/generalbytes/verification/service/ApplicantService.java
@@ -4,6 +4,8 @@ import com.generalbytes.verification.controller.RegisterNewApplicantReq;
 import com.generalbytes.verification.data.Applicant;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
@@ -12,11 +14,14 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class ApplicantService {
 
+    private static final Logger log = LoggerFactory.getLogger(ApplicantService.class);
+
     private final Cache<String, Applicant> CACHE =  CacheBuilder.newBuilder()
         .expireAfterWrite(90 * 60L, TimeUnit.SECONDS) // every SDK token is valid only for 90 minutes
         .build();
 
     public void addApplicant(RegisterNewApplicantReq req) {
+        log.info("Adding applicant {} to cache", req.getApplicantId());
         CACHE.put(req.getApplicantId(), new Applicant(req.getApplicantId(), req.getSdkToken(), req.getServerUrl(), Instant.now()));
     }
 

--- a/verification_site/src/main/resources/application-local.properties
+++ b/verification_site/src/main/resources/application-local.properties
@@ -1,2 +1,0 @@
-server.port=8443
-server.ssl.enabled=false

--- a/verification_site/src/main/resources/application.properties
+++ b/verification_site/src/main/resources/application.properties
@@ -1,6 +1,3 @@
-server.port=443
-security.require-ssl=true
-server.ssl.key-store=/etc/letsencrypt/live/example.com/keystore.p12
-server.ssl.key-store-password=<your-password>
-server.ssl.keyStoreType=PKCS12
-server.ssl.keyAlias=tomcat
+server.port=8443
+security.require-ssl=false
+logging.file.name=/var/log/batm/verification-site.log

--- a/verification_site/src/main/resources/static/onfido.html
+++ b/verification_site/src/main/resources/static/onfido.html
@@ -5,8 +5,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, minimal-ui">
         <meta name="apple-mobile-web-app-capable" content="yes">
         <meta name="apple-touch-fullscreen" content="yes">
-        <script src='https://assets.onfido.com/web-sdk-releases/6.4.0/onfido.min.js'></script>
-        <link rel='stylesheet' href='https://assets.onfido.com/web-sdk-releases/6.4.0/style.css'>
+        <script src='https://assets.onfido.com/web-sdk-releases/6.7.1/onfido.min.js'></script>
+        <link rel='stylesheet' href='https://assets.onfido.com/web-sdk-releases/6.7.1/style.css'>
         <link rel='stylesheet' href='style.css'>
     </head>
     <body>

--- a/verification_site/src/main/resources/static/style.css
+++ b/verification_site/src/main/resources/static/style.css
@@ -14,4 +14,7 @@ button {
         position: relative;
         top: 10%;
     }
+    .onfido-sdk-ui-CountrySelector-custom__input {
+        height: auto !important;
+    }
 }


### PR DESCRIPTION
 - better documentation specially for HTTPS certificate
 - changing default config to be able to run application in default (https config should not be required, it can be behind reverse proxy which is very common usecase these days)
 - upgrading to latest onfido release + fixing css style issue 