### PR TITLE
BPUB-1560 bitgo balance - prefer balanceString from response

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # buildscript - project id
 projectGroup=com.generalbytes.batm.public
-projectVersion=1.0.13-SNAPSHOT
+projectVersion=1.0.14-SNAPSHOT
 
 # buildscript - common dependency versions
 bitrafaelVersion=1.0.40

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
@@ -211,7 +211,7 @@ public class BitgoWallet implements IWallet, ICanSendMany {
 
     @Override
     public BigDecimal getCryptoBalance(String cryptoCurrency) {
-        if(cryptoCurrency == null) {
+        if (cryptoCurrency == null) {
             cryptoCurrency = getPreferredCryptoCurrency();
         }
         if (!getCryptoCurrencies().contains(cryptoCurrency)) {
@@ -220,30 +220,34 @@ public class BitgoWallet implements IWallet, ICanSendMany {
         cryptoCurrency = cryptoCurrency.toLowerCase();
         try {
             final Map<String, Object> response = api.getWalletById(cryptoCurrency, walletId);
-            if(response == null || response.isEmpty()) {
+            if (response == null || response.isEmpty()) {
                 return null;
             }
 
-            Object balanceObject = response.get("balance");
-            if(balanceObject == null || !(balanceObject instanceof Integer)) {
+            Object balanceObject = response.get("balanceString");
+            if(balanceObject == null) {
+                // fallback to older balance for backward compatibility only
+                balanceObject = response.get("balance");
+            }
+            if (balanceObject == null) {
                 return null;
             }
 
-            Integer balance = (Integer)balanceObject;
+            BigDecimal balance = new BigDecimal(balanceObject.toString());
             if (CryptoCurrency.BTC.getCode().equals(cryptoCurrency.toUpperCase())) {
-                return BigDecimal.valueOf(balance.intValue()).divide(Converters.BTC);
+                return balance.divide(Converters.BTC);
             } else if (CryptoCurrency.LTC.getCode().equals(cryptoCurrency.toUpperCase())) {
-                return BigDecimal.valueOf(balance.intValue()).divide(Converters.LTC);
+                return balance.divide(Converters.LTC);
             } else if (CryptoCurrency.BCH.getCode().equals(cryptoCurrency.toUpperCase())) {
-                return BigDecimal.valueOf(balance.intValue()).divide(Converters.BCH);
+                return balance.divide(Converters.BCH);
             } else if (CryptoCurrency.TBTC.getCode().equals(cryptoCurrency.toUpperCase())) {
-                return BigDecimal.valueOf(balance.intValue()).divide(Converters.TBTC);
+                return balance.divide(Converters.TBTC);
             } else if (CryptoCurrency.TLTC.getCode().equals(cryptoCurrency.toUpperCase())) {
-                return BigDecimal.valueOf(balance.intValue()).divide(Converters.TLTC);
+                return balance.divide(Converters.TLTC);
             } else if (CryptoCurrency.TBCH.getCode().equals(cryptoCurrency.toUpperCase())) {
-                return BigDecimal.valueOf(balance.intValue()).divide(Converters.TBCH);
+                return balance.divide(Converters.TBCH);
             }
-            return BigDecimal.valueOf(balance.intValue()).divide(new BigDecimal(1));
+            return balance.divide(new BigDecimal(1));
         } catch (HttpStatusIOException hse) {
             log.debug("getCryptoBalance error: {}", hse.getHttpBody());
         } catch (ErrorResponseException e) {


### PR DESCRIPTION
from documentation

> Balance Strings
> On most digital currencies, the wallet, transaction and address objects all contain a balance property.
> 
> In BitGo Platform V2, we have introduced a String suffix for all balances, as certain digital currencies (such as Ethereum) feature balance ranges which exceed those that can be stored as a typical number in JavaScript.
> 
> While the balance property will continue to be a number, it will not be available on all currencies across the V2 platform. We recommend using balanceString instead of balance for this reason, and balanceString will be available as a property over all digital currencies on V2. This applies to all number properties.
