### PR TITLE
Enables BitGoWallet's sendMany and sendCoins to use description

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoWallet.java
@@ -99,7 +99,7 @@ public class BitgoWallet implements IWallet, ICanSendMany {
         List<BitGoRecipient> recipients = transfers.stream()
             .map(transfer -> new BitGoRecipient(transfer.getDestinationAddress(), toSatoshis(transfer.getAmount(), cryptoCurrency)))
             .collect(Collectors.toList());
-        final BitGoSendManyRequest request = new BitGoSendManyRequest(recipients, walletPassphrase, this.numBlocks);
+        final BitGoSendManyRequest request = new BitGoSendManyRequest(recipients, walletPassphrase, description, this.numBlocks);
         try {
             return getResultTxId(api.sendMany(cryptoCurrency.toLowerCase(), this.walletId, request));
         } catch (HttpStatusIOException hse) {
@@ -114,7 +114,7 @@ public class BitgoWallet implements IWallet, ICanSendMany {
 
     @Override
     public String sendCoins(String destinationAddress, BigDecimal amount, String cryptoCurrency, String description) {
-        final BitGoCoinRequest request = new BitGoCoinRequest(destinationAddress, toSatoshis(amount, cryptoCurrency), walletPassphrase, this.numBlocks);
+        final BitGoCoinRequest request = new BitGoCoinRequest(destinationAddress, toSatoshis(amount, cryptoCurrency), walletPassphrase, description, this.numBlocks);
         try {
             return getResultTxId(api.sendCoins(cryptoCurrency.toLowerCase(), this.walletId, request));
         } catch (HttpStatusIOException hse) {

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoCoinRequest.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoCoinRequest.java
@@ -22,17 +22,19 @@ public class BitGoCoinRequest {
     private Integer amount;
     private String walletPassphrase;
     private Integer numBlocks;
+    private String comment;
 
 
-    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase) {
-      this(address, amount, walletPassphrase, 2);
+    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase, String comment) {
+      this(address, amount, walletPassphrase, comment, 2);
     }
 
-    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase, Integer numBlocks) {
+    public BitGoCoinRequest(String address, Integer amount, String walletPassphrase, String comment, Integer numBlocks) {
         this.address = address;
         this.amount = amount;
         this.walletPassphrase = walletPassphrase;
         this.numBlocks = numBlocks;
+        this.comment = comment;
     }
 
     public String getAddress() {
@@ -65,5 +67,13 @@ public class BitGoCoinRequest {
 
     public Integer getNumBlocks() {
       return numBlocks;
+    }
+
+    public String getComment() {
+      return comment;
+    }
+
+    public void setComment(String comment){
+      this.comment = comment;
     }
 }

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoSendManyRequest.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/dto/BitGoSendManyRequest.java
@@ -23,15 +23,17 @@ public class BitGoSendManyRequest {
     public List<BitGoRecipient> recipients;
     public String walletPassphrase;
     public Integer numBlocks;
+    public String comment;
 
-    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase){
-      this(recipients, walletPassphrase, 2);
+    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase, String comment){
+      this(recipients, walletPassphrase, comment, 2);
     }
 
-    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase, Integer numBlocks) {
+    public BitGoSendManyRequest(List<BitGoRecipient> recipients, String walletPassphrase, String comment, Integer numBlocks) {
         this.recipients = recipients;
         this.walletPassphrase = walletPassphrase;
         this.numBlocks = numBlocks;
+        this.comment = comment;
     }
 
     public static class BitGoRecipient {

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoAPITest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/wallets/bitgo/v2/BitgoAPITest.java
@@ -250,7 +250,7 @@ public class BitgoAPITest {
             final Integer amount = 10000;
             final String walletPassphrase = "JSZSuGNlHfgqPHjrp0eO";
 
-            final BitGoCoinRequest request = new BitGoCoinRequest(address, amount, walletPassphrase);
+            final BitGoCoinRequest request = new BitGoCoinRequest(address, amount, walletPassphrase, "TXID");
             String accessToken = "Bearer v2x8d5e9e46379dc328b2039a400a12b04ea986689b38107fd84cd339bc89e3fb21";
             String contentType = "application/json";
             Map<String, Object> result = localapi.sendCoins(coin, id, request);


### PR DESCRIPTION

Allows to pass a `String` object as the comment parameter for the API's request by leveraging the existing description parameter in `sendMany` and `sendCoins` methods. Use cases include transaction ID recording for audit, etc.