### PR TITLE
[BitpandaPro] Updated market and currency list for BitpandaProExchange

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchange.java
@@ -88,7 +88,12 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
         CryptoCurrency.BTC.getCode(),
         CryptoCurrency.ETH.getCode(),
         CryptoCurrency.XRP.getCode(),
-        CryptoCurrency.DOGE.getCode()
+        CryptoCurrency.DOGE.getCode(),
+        CryptoCurrency.USDT.getCode(),
+        CryptoCurrency.ADA.getCode(),
+        CryptoCurrency.LTC.getCode(),
+        CryptoCurrency.BCH.getCode(),
+        CryptoCurrency.TRX.getCode()
     );
     // from https://api.exchange.bitpanda.com/public/v1/instruments
     private static final Map<String, Integer> INSTRUMENT_AMOUNT_PRECISION = ImmutableMap.<String, Integer>builder()
@@ -100,6 +105,11 @@ public final class BitpandaProExchange implements IExchangeAdvanced, IRateSource
         .put("XRP_CHF", 0)
         .put("BTC_GBP", 5)
         .put("DOGE_EUR", 0)
+        .put("LTC_EUR", 5)
+        .put("USDT_EUR", 2)
+        .put("ADA_EUR", 3)
+        .put("BCH_EUR", 5)
+        .put("TRX_EUR", 1)
         .build()
     ;
 

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchangeTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitpandapro/BitpandaProExchangeTest.java
@@ -1,7 +1,13 @@
 package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bitpandapro;
 
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.ADA;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.BCH;
 import static com.generalbytes.batm.common.currencies.CryptoCurrency.BTC;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.DOGE;
 import static com.generalbytes.batm.common.currencies.CryptoCurrency.ETH;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.LTC;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.TRX;
+import static com.generalbytes.batm.common.currencies.CryptoCurrency.USDT;
 import static com.generalbytes.batm.common.currencies.CryptoCurrency.XRP;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.CHF;
 import static com.generalbytes.batm.common.currencies.FiatCurrency.EUR;
@@ -54,8 +60,8 @@ public class BitpandaProExchangeTest {
 
     @Test
     public void shouldFetchCryptoBalances() {
-        Stream.of(BTC, ETH, XRP).forEach(currency -> {
-            final BigDecimal balance = subject.getCryptoBalance(BTC.getCode());
+        Stream.of(BTC, ETH, XRP, ADA, USDT, TRX, BCH, DOGE, LTC ).forEach(currency -> {
+            final BigDecimal balance = subject.getCryptoBalance(currency.getCode());
             assertNotNull("getCryptoBalance(" + currency + ")", balance);
             assertTrue("negative balance", balance.compareTo(BigDecimal.ZERO) >= 0);
         });


### PR DESCRIPTION
- Left out new markets from BitpandaProRateSourceTest, because they are not a part of our staging environment

currencies:
- USDT
- ADA
- LTC
- BCH
- TRX

markets:
- LTC_EUR
- USDT_EUR
- ADA_EUR
- BCH_EUR
- TRX_EUR