### PR TITLE
BATM-2323 Temporary fix for unimplemented BittrexAccountService#withdrawFunds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # buildscript - project id
 projectGroup=com.generalbytes.batm.public
-projectVersion=1.0.30
+projectVersion=1.0.31
 
 # buildscript - common dependency versions
 bitrafaelVersion=1.0.40

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexAccountServiceCustom.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexAccountServiceCustom.java
@@ -1,0 +1,58 @@
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex;
+
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.dto.BittrexNewWithdrawal;
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.dto.BittrexWithdrawal;
+import org.knowm.xchange.bittrex.BittrexErrorAdapter;
+import org.knowm.xchange.bittrex.BittrexExchange;
+import org.knowm.xchange.bittrex.dto.BittrexException;
+import org.knowm.xchange.bittrex.service.BittrexAccountService;
+import org.knowm.xchange.client.ResilienceRegistries;
+import org.knowm.xchange.currency.Currency;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Temporary solution. Remove when withdrawal will be available in org.knowm.xchange:xchange-bitfinex
+ */
+//TODO: BATM-2327 remove this class
+public class BittrexAccountServiceCustom extends BittrexAccountService {
+
+    private final BittrexAuthenticatedCustom bittrexAuthenticatedCustom;
+
+    /**
+     * Constructor
+     *
+     * @param exchange
+     * @param bittrex
+     * @param resilienceRegistries
+     */
+    public BittrexAccountServiceCustom(BittrexExchange exchange, BittrexAuthenticatedCustom bittrex, ResilienceRegistries resilienceRegistries) {
+        super(exchange, bittrex, resilienceRegistries);
+        this.bittrexAuthenticatedCustom = bittrex;
+    }
+
+    @Override
+    public String withdrawFunds(Currency currency, BigDecimal amount, String address) throws IOException {
+        try {
+            return createNewWithdrawal(currency, amount, address).getId();
+        } catch (BittrexException e) {
+            throw BittrexErrorAdapter.adapt(e);
+        }
+    }
+
+    private BittrexWithdrawal createNewWithdrawal(Currency currency, BigDecimal amount, String address) throws IOException {
+        BittrexNewWithdrawal newWithdrawal = new BittrexNewWithdrawal();
+        newWithdrawal.setCurrencySymbol(currency.getCurrencyCode());
+        newWithdrawal.setQuantity(amount);
+        newWithdrawal.setCryptoAddress(address);
+
+        return this.bittrexAuthenticatedCustom.createNewWithdrawal(
+            this.apiKey,
+            System.currentTimeMillis(),
+            this.contentCreator,
+            this.signatureCreator,
+            newWithdrawal
+        );
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexAuthenticatedCustom.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexAuthenticatedCustom.java
@@ -1,0 +1,35 @@
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex;
+
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.dto.BittrexNewWithdrawal;
+import com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.dto.BittrexWithdrawal;
+import org.knowm.xchange.bittrex.BittrexAuthenticated;
+import org.knowm.xchange.bittrex.dto.BittrexException;
+import si.mazi.rescu.ParamsDigest;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+
+/**
+ * Temporary solution. Remove when withdrawal will be available in org.knowm.xchange:xchange-bitfinex
+ */
+//TODO: BATM-2327 remove this class
+@Path("v3")
+@Produces(MediaType.APPLICATION_JSON)
+public interface BittrexAuthenticatedCustom extends BittrexAuthenticated {
+
+    @POST
+    @Path("withdrawals")
+    @Consumes(MediaType.APPLICATION_JSON)
+    BittrexWithdrawal createNewWithdrawal(
+        @HeaderParam("Api-Key") String apiKey,
+        @HeaderParam("Api-Timestamp") Long timestamp,
+        @HeaderParam("Api-Content-Hash") ParamsDigest hash,
+        @HeaderParam("Api-Signature") ParamsDigest signature,
+        BittrexNewWithdrawal withdrawal)
+        throws IOException, BittrexException;
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexExchange.java
@@ -56,6 +56,7 @@ public class BittrexExchange implements IRateSourceAdvanced, IExchangeAdvanced {
     private Exchange exchange = null;
     private String apiKey;
     private String apiSecret;
+    private Exchange exchangeCustom = null; //TODO: BATM-2327 remove this field
 
     private static final HashMap<String,BigDecimal> rateAmounts = new HashMap<String, BigDecimal>();
     private static HashMap<String,Long> rateTimes = new HashMap<String, Long>();
@@ -78,6 +79,18 @@ public class BittrexExchange implements IRateSourceAdvanced, IExchangeAdvanced {
             this.exchange = ExchangeFactory.INSTANCE.createExchange(bfxSpec);
         }
         return this.exchange;
+    }
+
+    //TODO: BATM-2327 remove this method
+    private synchronized Exchange getExchangeCustom() throws TimeoutException {
+        if (this.exchangeCustom == null) {
+            RateLimiter.waitForPossibleCall(getClass());
+            ExchangeSpecification bfxSpec = new BittrexExchangeCustom().getDefaultExchangeSpecification();
+            bfxSpec.setApiKey(this.apiKey);
+            bfxSpec.setSecretKey(this.apiSecret);
+            this.exchangeCustom = ExchangeFactory.INSTANCE.createExchange(bfxSpec);
+        }
+        return this.exchangeCustom;
     }
 
     @Override
@@ -131,7 +144,7 @@ public class BittrexExchange implements IRateSourceAdvanced, IExchangeAdvanced {
         log.info("Calling Bittrex exchange (withdrawal destination: " + destinationAddress + " amount: " + amount + " " + cryptoCurrency + ")");
 
         try {
-            AccountService accountService = getExchange().getAccountService();
+            AccountService accountService = getExchangeCustom().getAccountService();
             RateLimiter.waitForPossibleCall(getClass());
             String result = accountService.withdrawFunds(Currency.getInstance(cryptoCurrency), amount, destinationAddress);
             log.info("Bittrex exchange (withdrawFunds) finished with result: {}", result);

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexExchangeCustom.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/BittrexExchangeCustom.java
@@ -1,0 +1,20 @@
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex;
+
+import org.knowm.xchange.bittrex.BittrexExchange;
+import org.knowm.xchange.bittrex.service.BittrexMarketDataService;
+import org.knowm.xchange.bittrex.service.BittrexTradeService;
+import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+
+/**
+ * Temporary solution. Remove when withdrawal will be available in org.knowm.xchange:xchange-bitfinex
+ */
+//TODO: BATM-2327 remove this class
+public class BittrexExchangeCustom extends BittrexExchange {
+
+    protected void initServices() {
+        BittrexAuthenticatedCustom bittrex = ExchangeRestProxyBuilder.forInterface(BittrexAuthenticatedCustom.class, this.getExchangeSpecification()).build();
+        this.marketDataService = new BittrexMarketDataService(this, bittrex, this.getResilienceRegistries());
+        this.accountService = new BittrexAccountServiceCustom(this, bittrex, this.getResilienceRegistries());
+        this.tradeService = new BittrexTradeService(this, bittrex, this.getResilienceRegistries());
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/dto/BittrexNewWithdrawal.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/dto/BittrexNewWithdrawal.java
@@ -1,0 +1,49 @@
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * Request DTO matching only user fields from https://bittrex.github.io/api/v3#/definitions/NewWithdrawal
+ */
+//TODO: BATM-2327 remove this class
+public class BittrexNewWithdrawal {
+
+    /**
+     * unique symbol of the currency to withdraw from (required)
+     */
+    private String currencySymbol;
+
+    /**
+     * quantity to withdraw (required)
+     */
+    private BigDecimal quantity;
+
+    /**
+     * crypto address to withdraw funds to
+     */
+    private String cryptoAddress;
+
+    public String getCurrencySymbol() {
+        return currencySymbol;
+    }
+
+    public void setCurrencySymbol(String currencySymbol) {
+        this.currencySymbol = currencySymbol;
+    }
+
+    public BigDecimal getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(BigDecimal quantity) {
+        this.quantity = quantity;
+    }
+
+    public String getCryptoAddress() {
+        return cryptoAddress;
+    }
+
+    public void setCryptoAddress(String cryptoAddress) {
+        this.cryptoAddress = cryptoAddress;
+    }
+}

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/dto/BittrexWithdrawal.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bittrex/dto/BittrexWithdrawal.java
@@ -1,0 +1,17 @@
+package com.generalbytes.batm.server.extensions.extra.bitcoin.exchanges.bittrex.dto;
+
+/**
+ * Response DTO matching only ID from https://bittrex.github.io/api/v3#/definitions/Withdrawal
+ */
+//TODO: BATM-2327 remove this class
+public class BittrexWithdrawal {
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
Missing implementation of BittrexAccountService#withdrawFunds in org.knowm.xchange:xchange-bitfinex library, created PR: https://github.com/knowm/XChange/pull/4159