### PR TITLE
BATM-2361 LN wallets - return preimage instead of payment hash

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lightningbitcoin/wallets/eclair/EclairWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lightningbitcoin/wallets/eclair/EclairWallet.java
@@ -93,7 +93,7 @@ public class EclairWallet extends AbstractLightningWallet {
                     return null;
                 case sent:
                     log.error("Payment sent: {}", sentInfo2);
-                    return sentInfo2.paymentHash;
+                    return sentInfo2.status.paymentPreimage;
                 case pending:
                     log.error("Payment pending: {}", sentInfo2);
                     continue;

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lightningbitcoin/wallets/lnd/LndWallet.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/lightningbitcoin/wallets/lnd/LndWallet.java
@@ -90,7 +90,7 @@ public class LndWallet extends AbstractLightningWallet {
             log.warn("SendPayment failed: {}", paymentResponse.payment_error);
             return null;
         }
-        return paymentResponse.payment_hash;
+        return paymentResponse.payment_preimage;
 
     }
 


### PR DESCRIPTION
preimage should be stored in transaction record instead of payment hash (i.e. hash of the preimage) because it could be used to prove an invoice was paid

Any non null string returned is considered as successful sending