### PR TITLE
BATM-3007 BNB tag feature fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # buildscript - project id
 projectGroup=com.generalbytes.batm.public
-projectVersion=1.0.58
+projectVersion=1.0.58.1
 
 # buildscript - common dependency versions
 bitrafaelVersion=1.0.44

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/BitcoinExtension.java
@@ -618,6 +618,7 @@ public class BitcoinExtension extends AbstractExtension {
         result.add(CryptoCurrency.BCH.getCode());
         result.add(CryptoCurrency.EGLD.getCode());
         result.add(CryptoCurrency.USDTTRON.getCode());
+        result.add(CryptoCurrency.BNB.getCode());
         return result;
     }
 


### PR DESCRIPTION
BNB needs to be in a list of supported currencies of any extension, otherwise the Tag Feature is not set (tag not required on terminal)