### PR TITLE
Add AUD as a support fiat to FtxComExchange

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/ftx/FtxComExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/ftx/FtxComExchange.java
@@ -34,6 +34,7 @@ public class FtxComExchange extends FtxExchange {
         SUPPORTED_FIATS.add(FiatCurrency.EUR.getCode());
         SUPPORTED_FIATS.add(FiatCurrency.GBP.getCode());
         SUPPORTED_FIATS.add(FiatCurrency.USD.getCode());
+        SUPPORTED_FIATS.add(FiatCurrency.AUD.getCode());
 
         SUPPORTED_CRYPTOS.add(CryptoCurrency.BAT.getCode());
         SUPPORTED_CRYPTOS.add(CryptoCurrency.BCH.getCode());


### PR DESCRIPTION
AUD is a supported fiat on ftx.com, we've tested it and it works.