### PR TITLE
Adding GQ currency to coingecko rates

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/sources/coingecko/CoinGeckoRateSource.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/sources/coingecko/CoinGeckoRateSource.java
@@ -99,6 +99,7 @@ public class CoinGeckoRateSource implements IRateSource {
         CRYPTOCURRENCIES.put(CryptoCurrency.TENT.getCode(), "tent");
         CRYPTOCURRENCIES.put(CryptoCurrency.XZC.getCode(), "zcoin");
         CRYPTOCURRENCIES.put(CryptoCurrency.ZPAE.getCode(), "zelaapayae");
+        CRYPTOCURRENCIES.put(CryptoCurrency.GQ.getCode(), "outer-ring");
     }
 
     private final CoinGeckoV3API api;


### PR DESCRIPTION
Adding GQ currency to coingecko rates.

#### URLs:  
- https://api.coingecko.com/api/v3/coins/list
- https://www.coingecko.com/es/monedas/outer-ring 
- Example: https://api.coingecko.com/api/v3/simple/price?ids=outer-ring&vs_currencies=usd
