### PR TITLE
BATM-5283 - Wrong XRP amount

### DIFF
--- a/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/Converters.java
+++ b/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/Converters.java
@@ -29,7 +29,7 @@ public class Converters {
     public static final BigDecimal GQ = BigDecimal.TEN.pow(18);
     public static final BigDecimal USDT = BigDecimal.TEN.pow(6);
     public static final BigDecimal USDTTRON = BigDecimal.TEN.pow(6);
-    public static final BigDecimal XRP = BigDecimal.TEN.pow(8);
+    public static final BigDecimal XRP = BigDecimal.TEN.pow(6);
     public static final BigDecimal VERUM = BigDecimal.TEN.pow(8);
 
     public static final BigDecimal TBCH = BigDecimal.TEN.pow(8);


### PR DESCRIPTION
The customer has on the BitGO wallet 100x more XRP than our server reflects.