### PR TITLE
Added RON fiat and egld to binancecom and binancecom ratesource.

### DIFF
--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceComExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/binance/BinanceComExchange.java
@@ -35,6 +35,7 @@ public class BinanceComExchange extends BinanceExchange {
         SUPPORTED_FIATS.add(FiatCurrency.EUR.getCode());
         SUPPORTED_FIATS.add(FiatCurrency.GBP.getCode());
         SUPPORTED_FIATS.add(FiatCurrency.RUB.getCode());
+        SUPPORTED_FIATS.add(FiatCurrency.RON.getCode());
         SUPPORTED_FIATS.add(CryptoCurrency.BUSD.getCode());
         SUPPORTED_FIATS.add(CryptoCurrency.DAI.getCode());
         SUPPORTED_FIATS.add(CryptoCurrency.USDC.getCode());

--- a/server_extensions_extra/src/main/resources/batm-extensions.xml
+++ b/server_extensions_extra/src/main/resources/batm-extensions.xml
@@ -697,6 +697,7 @@
             <cryptocurrency>DOGE</cryptocurrency>
             <cryptocurrency buyonly="true">ETH</cryptocurrency>
             <cryptocurrency>GRS</cryptocurrency>
+            <cryptocurrency>EGLD</cryptocurrency>
             <cryptocurrency>LSK</cryptocurrency>
             <cryptocurrency>LTC</cryptocurrency>
             <cryptocurrency>NANO</cryptocurrency>
@@ -723,6 +724,7 @@
             <cryptocurrency>DOGE</cryptocurrency>
             <cryptocurrency>ETH</cryptocurrency>
             <cryptocurrency>GRS</cryptocurrency>
+            <cryptocurrency>EGLD</cryptocurrency>
             <cryptocurrency>LSK</cryptocurrency>
             <cryptocurrency>LTC</cryptocurrency>
             <cryptocurrency>NANO</cryptocurrency>


### PR DESCRIPTION
I added the RON fiat on binance.com to use USDT and EGLD.