### PR TITLE
BATM-5894 and BATM-5900 bug fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # buildscript - project id
 projectGroup=com.generalbytes.batm.public
-projectVersion=1.3.8
+projectVersion=1.3.9
 
 # buildscript - common dependency versions
 bitrafaelVersion=1.0.44

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitfinex/BitfinexExchange.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/bitcoin/exchanges/bitfinex/BitfinexExchange.java
@@ -77,6 +77,9 @@ public class BitfinexExchange implements IExchangeAdvanced, IRateSourceAdvanced 
 
     static {
         FIAT_CURRENCIES.add(FiatCurrency.USD.getCode());
+        FIAT_CURRENCIES.add(FiatCurrency.EUR.getCode());
+        FIAT_CURRENCIES.add(FiatCurrency.GBP.getCode());
+        FIAT_CURRENCIES.add(FiatCurrency.JPY.getCode());
         FIAT_CURRENCIES.add(CryptoCurrency.USDT.getCode());
     }
 

--- a/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/watchlists/ca/ParsedSanctions.java
+++ b/server_extensions_extra/src/main/java/com/generalbytes/batm/server/extensions/extra/watchlists/ca/ParsedSanctions.java
@@ -36,7 +36,7 @@ public class ParsedSanctions implements IParsedSanctions {
                         matchedParties.add(new Match(getPartyId(item), 100));
                         continue;
                     }
-                    if (containsSubstring(lastName, item.getAliases())) {
+                    if (aliasContainsLastName(lastName, item.getAliases())) {
                         matchedParties.add(new Match(getPartyId(item), 50));
                     }
                 }
@@ -56,7 +56,7 @@ public class ParsedSanctions implements IParsedSanctions {
                     }
                     continue;
                 }
-                if (containsSubstring(lastName, item.getAliases())) {
+                if (aliasContainsLastName(lastName, item.getAliases())) {
                     candidateRecords.add(item);
                 }
             }
@@ -110,5 +110,19 @@ public class ParsedSanctions implements IParsedSanctions {
 
     private boolean containsSubstring(String substring, String input) {
         return input != null && input.toLowerCase().contains(substring.toLowerCase());
+    }
+
+    private boolean aliasContainsLastName(String lastName, String alias) {
+        if (alias == null) {
+            return false;
+        }
+        String aliasNoSeparators = alias.replaceAll(";", "");
+        String[] aliasWords = aliasNoSeparators.split(" ");
+        for (String aliasWord : aliasWords) {
+            if (aliasWord.equalsIgnoreCase(lastName)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/watchlists/ca/ParsedSanctionsTest.java
+++ b/server_extensions_extra/src/test/java/com/generalbytes/batm/server/extensions/extra/watchlists/ca/ParsedSanctionsTest.java
@@ -58,6 +58,15 @@ public class ParsedSanctionsTest {
         assertTrue(result.isEmpty());
     }
 
+    @Test
+    public void testSearchAliasNoMatch() {
+        final Record record = createRecord("Vladimir Rudolfovich", "SOLOVYOV");
+        record.setAliases("Владимир Рудольфович Соловьёв; Vladimir Solovev; Soloviev");
+        final ParsedSanctions parsedSanctions = initializeParsedSanctions(record);
+        Set<Match> result = parsedSanctions.search("Unknown", "Vlad");
+        assertTrue(result.isEmpty());
+    }
+
     private void assertMatch(Set<Match> result, int i) {
         assertEquals(1, result.size());
         final Match foundMatch = result.iterator().next();


### PR DESCRIPTION
BATM-5894 Added support for EUR, GBP and JPY at BitfinexExchange
BATM-5900 Fixed false positives when scanning CA sanction list and matching using aliases