### PR TITLE
CF-874: Add a method to override verification web URL (#1040) (#1051)

### DIFF
--- a/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/aml/verification/IIdentityVerificationProvider.java
+++ b/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/aml/verification/IIdentityVerificationProvider.java
@@ -7,4 +7,16 @@ public interface IIdentityVerificationProvider {
      * @param identityPublicId Some providers use this in the webhook, or it is just displayed on the provider's dashboard
      */
     CreateApplicantResponse createApplicant(String customerLanguage, String identityPublicId);
+
+    /**
+     * Overrides the verification web URL for a specific verification process.
+     * The purpose of this method is to enable modification of the verification web URL if necessary.
+     * It is expected to fall back to the original URL obtained from {@link #createApplicant(String, String)} for backwards compatibility.
+     *
+     * @param overrideRequest the request object containing the original verification web URL and additional details needed to process the override.
+     * @return an {@code OverrideVerificationWebUrlResponse} object containing the overridden verification web URL, which defaults to the original URL provided in the request.
+     */
+    default OverrideVerificationWebUrlResponse overrideVerificationWebUrl(OverrideVerificationWebUrlRequest overrideRequest) {
+        return new OverrideVerificationWebUrlResponse(overrideRequest.getOriginalVerificationWebUrl());
+    }
 }

--- a/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/aml/verification/OverrideVerificationWebUrlRequest.java
+++ b/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/aml/verification/OverrideVerificationWebUrlRequest.java
@@ -1,0 +1,55 @@
+package com.generalbytes.batm.server.extensions.aml.verification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Request object for overriding verification web URL.
+ */
+@Setter
+@Getter
+@AllArgsConstructor
+public class OverrideVerificationWebUrlRequest {
+
+    /**
+     * The original verification web URL associated with the verification process.
+     * This URL is typically provided by the identity verification provider and can be overridden for specific
+     * use cases during the verification process.
+     */
+    private String originalVerificationWebUrl;
+
+    /**
+     * Represents the type of related transaction being performed.
+     * The value is an integer where each number corresponds to a specific transaction type:
+     * <li>{@code null} if unknown (e.g., old invoked from old terminal)</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.ITransactionPreparation#TYPE_BUY_CRYPTO}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.ITransactionPreparation#TYPE_SELL_CRYPTO}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.ITransactionPreparation#TYPE_WITHDRAW_CASH}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.ITransactionPreparation#TYPE_CASHBACK}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.ITransactionPreparation#TYPE_ORDER_CRYPTO}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.ITransactionPreparation#TYPE_DEPOSIT_CASH}</li>
+     */
+    private Integer transactionType;
+
+    /**
+     * Specifies the direction of the related transaction.
+     * The value is an integer where each number corresponds to a specific direction:
+     * <li>{@code null} if unknown (e.g., old invoked from old terminal)</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.IExtensionContext#DIRECTION_NONE}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.IExtensionContext#DIRECTION_BUY_CRYPTO}</li>
+     * <li>{@link com.generalbytes.batm.server.extensions.IExtensionContext#DIRECTION_SELL_CRYPTO}</li>
+     */
+    private Integer direction;
+
+    /**
+     * The identity public ID.
+     */
+    private String identityPublicId;
+
+    /**
+     * Terminal serial number. Not always available, might be null in case it is not invoked by terminal (e.g., by an extension).
+     */
+    private String serialNumber;
+
+}

--- a/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/aml/verification/OverrideVerificationWebUrlResponse.java
+++ b/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/aml/verification/OverrideVerificationWebUrlResponse.java
@@ -1,0 +1,32 @@
+package com.generalbytes.batm.server.extensions.aml.verification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Response object for overriding verification URL.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class OverrideVerificationWebUrlResponse {
+
+    /**
+     * The overridden verification URL (verification link).
+     * <b>It must not be null or blank.</b>
+     */
+    private String verificationWebUrl;
+
+    /**
+     * Flag to control whether the verification link should be sent via SMS.
+     * When false (default), the verification link will be sent automatically via SMS.
+     * When true, sending SMS will be skipped. This allows distributing the link separately or via different channel.
+     */
+    private boolean skipSendingSms = false;
+
+    public OverrideVerificationWebUrlResponse(String verificationWebUrl) {
+        this.verificationWebUrl = verificationWebUrl;
+    }
+
+}


### PR DESCRIPTION
* CF-874: Add a method to override verification web URL in identity verification providers

* CF-874: Lombok and javadoc update

(cherry picked from commit 14aadf49a24618dec563fbc6ba40f9e1a351d469)