### PR TITLE
BATM-7666 - Java 11 must be mentioned as a minimum for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Note for developers
 ==========
 
 Requirements:
-* Linux is required in order to run compilers and tests.
-* Java **1.8** (we recommend using https://sdkman.io/ for managing multiple JDK versions on your computer)
+* Linux is required in order to run compilers and tests. We recommend working on Ubuntu 24.04+
+* Java **17** (we recommend using https://sdkman.io/ for managing multiple JDK versions on your computer)
 * Gradle
 
 When you implement support for a new crypto-coin, please add it to **server_extensions_extra** - so that it may get into the default CAS distribution ready to be used by other operators.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Note for developers
 
 Requirements:
 * Linux is required in order to run compilers and tests. We recommend working on Ubuntu 24.04+
-* Java **17** (we recommend using https://sdkman.io/ for managing multiple JDK versions on your computer)
+* Java **11** (we recommend using https://sdkman.io/ for managing multiple JDK versions on your computer)
 * Gradle
 
 When you implement support for a new crypto-coin, please add it to **server_extensions_extra** - so that it may get into the default CAS distribution ready to be used by other operators.

--- a/batm_ssh_tunnel/README.md
+++ b/batm_ssh_tunnel/README.md
@@ -7,10 +7,10 @@ Using ssh tunnels is recomended when BATM server wants to communicate to bitcoin
 
 ## To Install (tested on ubuntu server 24.04):
 
-0. Install Java 17 (used for compilation of client and running)
+0. Install Java 11 (used for compilation of client and running)
 ```
 apt update
-apt install openjdk-17-jdk-headless
+apt install openjdk-11-jdk-headless
 ```
 1. Clone this repository to download source code
 ```

--- a/batm_ssh_tunnel/README.md
+++ b/batm_ssh_tunnel/README.md
@@ -5,12 +5,12 @@ Application is listening on port 22222 and is waiting for BATM server connection
 Using ssh tunnels is recomended when BATM server wants to communicate to bitcoind or similar node as it adds additional layer of encryption.
 
 
-## To Install (tested on ubuntu server 18.04):
+## To Install (tested on ubuntu server 24.04):
 
-0. Install Java 8 (used for compilation of client and running)
+0. Install Java 17 (used for compilation of client and running)
 ```
 apt update
-apt install openjdk-8-jdk-headless
+apt install openjdk-17-jdk-headless
 ```
 1. Clone this repository to download source code
 ```


### PR DESCRIPTION
In documentation we mention Java 8. We need to mention Java 11 as a minimum version