### PR TITLE
CF-1145: Add QR code setter to ITransactionPreparation and ITransactionRequest

### DIFF
--- a/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/ITransactionPreparation.java
+++ b/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/ITransactionPreparation.java
@@ -160,6 +160,14 @@ public interface ITransactionPreparation {
         return null;
     }
 
+    /**
+     * Text to be rendered into a QR code and displayed alongside the error message.
+     *
+     * @param text QR code text, or null if no QR code should be displayed
+     */
+    default void setErrorQrCodeText(String text) {
+    }
+
 
     /**
      * Maximum cash amount that customer can insert/sell into/to machine

--- a/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/ITransactionRequest.java
+++ b/server_extensions_api/src/main/java/com/generalbytes/batm/server/extensions/ITransactionRequest.java
@@ -200,6 +200,14 @@ public interface ITransactionRequest {
     }
 
     /**
+     * Text to be rendered into a QR code and displayed alongside the error message.
+     *
+     * @param text QR code text, or null if no QR code should be displayed
+     */
+    default void setErrorQrCodeText(String text) {
+    }
+
+    /**
      * Whether the terminal should show a post-transaction dialog to the customer.
      */
     default boolean shouldShowPostTransactionDialog() {


### PR DESCRIPTION
…onRequest

Adds setErrorQrCodeText(String) matching the existing getter/setter convention used for error messages.